### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/event-listener"
 documentation = "https://docs.rs/event-listener"
 keywords = ["condvar", "eventcount", "wake", "blocking", "park"]
 categories = ["asynchronous", "concurrency"]
-readme = "README.md"
 
 [dev-dependencies]
 futures = { version = "0.3.5", default-features = false, features = ["std"] }


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.