### PR TITLE
Use the parking crate instead of threading APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml and .clippy.toml.
-        rust: ['1.36']
+        rust: ['1.39']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["condvar", "eventcount", "wake", "blocking", "park"]
 categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
+[dependencies]
+parking = "2.0.0"
+
 [dev-dependencies]
-futures = { version = "0.3", default-features = false, features = ["std"] }
 waker-fn = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -930,7 +930,9 @@ impl List {
                         State::Notified(_) => {}
                         State::Created => {}
                         State::Polling(w) => w.wake(),
-                        State::Waiting(t) => { t.unpark(); },
+                        State::Waiting(t) => {
+                            t.unpark();
+                        }
                     }
 
                     // Update the counter.
@@ -959,7 +961,9 @@ impl List {
                         State::Notified(_) => {}
                         State::Created => {}
                         State::Polling(w) => w.wake(),
-                        State::Waiting(t) => { t.unpark(); },
+                        State::Waiting(t) => {
+                            t.unpark();
+                        }
                     }
 
                     // Update the counter.


### PR DESCRIPTION
In order to avoid the downsides of user-invoked `thread::Thread::unpark()`, this PR imports the `Parking` crate for use in parking/unparking threads.

Is there a reason why the original author elected to use `std::thread` instead of `parking`?