### PR TITLE
Implement a new algorithm to make this crate `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: rustup target add thumbv7m-none-eabi
+      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,15 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [dependencies]
-concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", default-features = false }
+concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", branch = "loom", default-features = false }
 parking = { version = "2", optional = true }
+portable-atomic = { version = "0.3", default-features = false, optional = true }
 
+# Enables loom testing. This feature is permanently unstable and the API may
+# change at any time.
 [target.'cfg(loom)'.dependencies]
-loom = "0.5"
+loom = { version = "0.5", optional = true }
+concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", branch = "loom", features = ["loom"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,15 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [dependencies]
-parking = "2.0.0"
+concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", default-features = false }
+parking = { version = "2", optional = true }
+
+[target.'cfg(loom)'.dependencies]
+loom = "0.5"
+
+[features]
+default = ["std"]
+std = ["parking", "concurrent-queue/std"]
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ portable-atomic = { version = "0.3", default-features = false, optional = true }
 # change at any time.
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.5", optional = true }
-concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", branch = "loom", features = ["loom"] }
+concurrent-queue = { git = "https://github.com/smol-rs/concurrent-queue.git", branch = "loom", default-features = false, features = ["loom"] }
 
 [features]
 default = ["std"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -20,6 +20,18 @@ fn bench_events(c: &mut Criterion) {
             }
         });
     });
+
+    c.bench_function("notify_single", |b| {
+        let ev = Event::new();
+
+        b.iter(|| {
+            for _ in 0..COUNT {
+                let handle = ev.listen();
+                ev.notify(1);
+                handle.wait();
+            }
+        });
+    });
 }
 
 criterion_group!(benches, bench_events);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //!
 //!     // Wait for a notification and continue the loop.
 //!     listener.wait();
-//! } 
+//! }
 //! # // Sleep to prevent MIRI failure, https://github.com/rust-lang/miri/issues/1371
 //! # std::thread::sleep(std::time::Duration::from_secs(3));
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,9 @@
 //!
 //!     // Wait for a notification and continue the loop.
 //!     listener.wait();
-//! }
+//! } 
+//! # // Sleep to prevent MIRI failure, https://github.com/rust-lang/miri/issues/1371
+//! # std::thread::sleep(std::time::Duration::from_secs(3));
 //! ```
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! # Features
 //!
-//! There is also a `portable-atomic` feature, which uses a polyfill from the
+//! There is a `portable-atomic` feature, which uses a polyfill from the
 //! [`portable-atomic`] crate to provide atomic operations on platforms that do not support them.
 //! See the [`README`] for the [`portable-atomic`] crate for more information on how to use it on
 //! single-threaded targets. Note that even with this feature enabled, `event-listener` still

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ use alloc::sync::Arc;
 
 use core::fmt;
 use core::future::Future;
-use core::mem::{ManuallyDrop, MaybeUninit, forget};
+use core::mem::{forget, ManuallyDrop, MaybeUninit};
 use core::ptr;
 use core::task::{Context, Poll, Waker};
 
@@ -749,7 +749,7 @@ impl Listener {
             }
 
             /// The task() closure may clone a user-defined waker, which can panic.
-            /// 
+            ///
             /// This panic would leave the listener in the `WritingTask` state, which will
             /// lead to an infinite loop. This guard resets it back to the original state.
             struct ResetState<'a>(&'a AtomicUsize, State);

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,478 @@
+//! Implementation of the inner listener primitive.
+//!
+//! This is stored in a `ConcurrentQueue` inside of an event and in the `EventListener` handle.
+//! This means that the maximum refcount of the event is 2. In addition, it will either be
+//! allocated to the heap or to a buffer inside of the `Event` itself.
+//!
+//! This module aims to create a primitive that fulfills all of these requirements while being
+//! safe to use from the main module.
+
+use super::Inner;
+
+use alloc::boxed::Box;
+
+use core::cell::UnsafeCell as StdUnsafeCell;
+use core::mem::{forget, MaybeUninit};
+use core::ptr::{self, NonNull};
+use core::task::Waker;
+
+#[cfg(feature = "std")]
+use std::panic::{RefUnwindSafe, UnwindSafe};
+
+use crate::busy_wait;
+use crate::sync::atomic::Ordering::{AcqRel, Acquire, Release, SeqCst};
+use crate::sync::atomic::{fence, AtomicBool, AtomicUsize};
+use crate::sync::UnsafeCell;
+
+#[cfg(not(loom))]
+use crate::sync::AtomicWithMut;
+
+#[cfg(feature = "std")]
+use crate::sync::Unparker;
+
+/// The internal listener for the `Event`.
+pub(crate) struct Listener {
+    /// The current state of the listener.
+    state: AtomicUsize,
+
+    /// The task that this listener is blocked on.
+    task: UnsafeCell<MaybeUninit<Task>>,
+}
+
+/// A cached `Listener` on the stack.
+pub(crate) struct CachedListener {
+    /// Whether or not the listener is cached.
+    cached: AtomicBool,
+
+    /// The cached listener.
+    listener: StdUnsafeCell<MaybeUninit<Listener>>,
+}
+
+unsafe impl Send for Listener {}
+unsafe impl Sync for Listener {}
+
+#[cfg(feature = "std")]
+impl UnwindSafe for Listener {}
+#[cfg(feature = "std")]
+impl RefUnwindSafe for Listener {}
+
+impl Default for Listener {
+    fn default() -> Self {
+        // Assume that listeners start off as queued.
+        Self {
+            state: AtomicUsize::new(ListenerStatus::Created as usize | QUEUED_MASK),
+            task: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+}
+
+impl Default for CachedListener {
+    fn default() -> Self {
+        Self {
+            cached: AtomicBool::new(false),
+            listener: MaybeUninit::uninit().into(),
+        }
+    }
+}
+
+impl Listener {
+    /// Allocate a new `Listener`.
+    pub(crate) fn alloc(event: &Inner) -> NonNull<Listener> {
+        // If the cache is open, then we don't have to allocate.
+        if !event.cached.cached.swap(true, Acquire) {
+            // SAFETY: The cache is open and the queue is empty, so we know that the cache is
+            // valid to write to.
+            let ptr = event.cached.listener.get();
+            unsafe {
+                ptr.write(MaybeUninit::new(Listener::default()));
+                return NonNull::new_unchecked(ptr as *mut Listener);
+            }
+        }
+
+        // The cache is unavailable, so we have to allocate.
+        let listener = Box::new(Listener::default());
+        let ptr = Box::into_raw(listener);
+
+        unsafe { NonNull::new_unchecked(ptr) }
+    }
+
+    /// Begin waiting on this `Listener`.
+    ///
+    /// Returns `true` if the listener was notified.
+    pub(crate) fn wait(this: NonNull<Self>, task: impl FnOnce() -> Task) -> bool {
+        let this = unsafe { this.as_ref() };
+        let mut state: State = this.state.load(Acquire).into();
+
+        loop {
+            match state.status {
+                ListenerStatus::Created | ListenerStatus::Task => {
+                    // Try to "lock" the listener.
+                    let writing_state = State {
+                        status: ListenerStatus::WritingTask,
+                        ..state
+                    };
+                    if let Err(e) = this.state.compare_exchange(
+                        state.into(),
+                        writing_state.into(),
+                        SeqCst,
+                        SeqCst,
+                    ) {
+                        state = e.into();
+                        busy_wait();
+                        continue;
+                    }
+
+                    // We now hold the "lock" on the task slot. Write the task to the slot.
+                    let guard = ResetState(&this.state, state);
+                    let task = task();
+                    forget(guard);
+
+                    let task = this.task.with_mut(|slot| unsafe {
+                        // If there already was a task, swap it out and wake it.
+                        if state.status == ListenerStatus::Task {
+                            Some(ptr::replace(slot.cast(), task))
+                        } else {
+                            ptr::write(slot.cast(), task);
+                            None
+                        }
+                    });
+
+                    // We are done writing to the task slot. Transition to `Task`.
+                    // No other thread can transition to `Task` from `WritingTask`.
+                    state.status = ListenerStatus::Task;
+                    this.state.store(state.into(), Release);
+
+                    // If we yielded a task, wake it now.
+                    if let Some(task) = task {
+                        task.wake();
+                    }
+
+                    // Now, we should wait for a notification.
+                    return false;
+                }
+                ListenerStatus::WritingTask => {
+                    // We must be in the process of being woken up. Wait for the task to be written.
+                    busy_wait();
+                }
+                ListenerStatus::Notified | ListenerStatus::NotifiedAdditional => {
+                    // We were already notified. We are done.
+                    return true;
+                }
+                ListenerStatus::Orphaned => {
+                    // The event was dropped. We are done.
+                    return false;
+                }
+            }
+
+            /// The task() closure may clone a user-defined waker, which can panic.
+            ///
+            /// This panic would leave the listener in the `WritingTask` state, which will
+            /// lead to an infinite loop. This guard resets it back to the original state.
+            struct ResetState<'a>(&'a AtomicUsize, State);
+
+            impl Drop for ResetState<'_> {
+                fn drop(&mut self) {
+                    self.0.store(self.1.into(), Release);
+                }
+            }
+        }
+    }
+
+    /// Notify this `Listener`.
+    ///
+    /// Returns `true` if the listener was successfully notified. This implicity deques the listener and
+    /// may destroy this listener if the top-level EventListener has already orphaned it.
+    pub(crate) fn notify(entry: NonNull<Listener>, additional: bool, event: &Inner) -> bool {
+        let this = unsafe { entry.as_ref() };
+
+        let new_state = if additional {
+            ListenerStatus::NotifiedAdditional
+        } else {
+            ListenerStatus::Notified
+        };
+        let new_state = State {
+            status: new_state,
+            queued: false,
+        };
+
+        let mut state: State = this.state.load(Acquire).into();
+
+        let notified = loop {
+            // Determine what state we're in.
+            match state.status {
+                ListenerStatus::Created
+                | ListenerStatus::Notified
+                | ListenerStatus::NotifiedAdditional => {
+                    // Indicate that the listener was notified and is now unqueued.
+                    if let Err(e) =
+                        this.state
+                            .compare_exchange(state.into(), new_state.into(), AcqRel, Acquire)
+                    {
+                        // Someone got to it before we did, try again.
+                        state = e.into();
+                        continue;
+                    } else {
+                        // We successfully notified the listener.
+                        break true;
+                    }
+                }
+                ListenerStatus::WritingTask => {
+                    // The listener is currently writing the task, wait until they finish.
+                }
+                ListenerStatus::Task => {
+                    // We need to wake the listener before we can do anything else.
+                    let writing_state = State {
+                        queued: state.queued,
+                        status: ListenerStatus::WritingTask,
+                    };
+
+                    if let Err(e) = this.state.compare_exchange(
+                        state.into(),
+                        writing_state.into(),
+                        AcqRel,
+                        Acquire,
+                    ) {
+                        // Someone else got to it before we did.
+                        state = e.into();
+                        busy_wait();
+                        continue;
+                    }
+
+                    // SAFETY: Since we hold the lock, we can now read out the primitive.
+                    let task = this
+                        .task
+                        .with_mut(|task| unsafe { ptr::read(task.cast::<Task>()) });
+
+                    // SAFETY: No other code makes a change when `WritingTask` is detected.
+                    this.state.store(new_state.into(), Release);
+
+                    // Wake the task up and return.
+                    task.wake();
+                    break true;
+                }
+                ListenerStatus::Orphaned => {
+                    // This task is no longer being monitored.
+                    break false;
+                }
+            }
+        };
+
+        // If the listener orphaned this listener, we need to destroy it.
+        if let ListenerStatus::Orphaned = state.status {
+            // Create a memory fence and then destroy it.
+            fence(Acquire);
+            Self::destroy(entry, event);
+        }
+
+        notified
+    }
+
+    /// Orphan this `Listener`.
+    ///
+    /// Returns `Some<bool>` if a notification was discarded. The `bool` is `true`
+    /// if the notification was an additional notification. If this entry was already
+    /// removed from the queue, this destroys the entry as well.
+    pub(crate) fn orphan(entry: NonNull<Listener>, event: &Inner) -> Option<bool> {
+        let this = unsafe { entry.as_ref() };
+        let mut state: State = this.state.load(Acquire).into();
+
+        let result = loop {
+            match state.status {
+                ListenerStatus::Created
+                | ListenerStatus::Notified
+                | ListenerStatus::NotifiedAdditional => {
+                    let new_state = State {
+                        status: ListenerStatus::Orphaned,
+                        queued: state.queued,
+                    };
+
+                    // Indicate that the listener was notified.
+                    if let Err(new_state) =
+                        this.state
+                            .compare_exchange(state.into(), new_state.into(), AcqRel, Acquire)
+                    {
+                        // We failed to transition to `Orphaned`. Try again.
+                        state = new_state.into();
+                        busy_wait();
+                        continue;
+                    }
+
+                    match state.status {
+                        ListenerStatus::Notified => break Some(false),
+                        ListenerStatus::NotifiedAdditional => break Some(true),
+                        _ => break None,
+                    }
+                }
+                ListenerStatus::WritingTask => {
+                    // We're in the middle of being notified, wait for them to finish writing first.
+                }
+                ListenerStatus::Task => {
+                    let writing_state = State {
+                        queued: state.queued,
+                        status: ListenerStatus::WritingTask,
+                    };
+
+                    if let Err(new_state) = this.state.compare_exchange(
+                        state.into(),
+                        writing_state.into(),
+                        AcqRel,
+                        Acquire,
+                    ) {
+                        // Someone else got to it before we did.
+                        state = new_state.into();
+                        busy_wait();
+                        continue;
+                    }
+
+                    // SAFETY: Since we hold the lock, we can now drop the primitive.
+                    this.task
+                        .with_mut(|task| unsafe { ptr::drop_in_place(task.cast::<Task>()) });
+
+                    // SAFETY: No other code makes a change when `WritingTask` is detected.
+                    state.status = ListenerStatus::Orphaned;
+                    this.state.store(state.into(), Release);
+
+                    // We did not discard a notification.
+                    break None;
+                }
+                ListenerStatus::Orphaned => {
+                    // We have already been orphaned.
+                    break None;
+                }
+            }
+
+            busy_wait();
+            state = this.state.load(Acquire).into();
+        };
+
+        // If the entry is dequeued, we need to destroy it.
+        if !state.queued {
+            fence(Acquire);
+            Self::destroy(entry, event);
+        }
+
+        // At this point, if we are no longer queued, we can drop the listener.
+        result
+    }
+
+    fn destroy(entry: NonNull<Listener>, event: &Inner) {
+        // If this pointer is equal to the cache pointer, we can just clear the cache.
+        let cache_ptr = event.cached.listener.get().cast();
+        if entry.as_ptr() == cache_ptr {
+            unsafe {
+                ptr::drop_in_place(cache_ptr);
+            }
+
+            // Mark the cache as empty.
+            event.cached.cached.store(false, Release);
+
+            return;
+        }
+
+        drop(unsafe { Box::from_raw(entry.as_ptr()) });
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        let Self {
+            ref mut state,
+            ref mut task,
+        } = self;
+
+        state.with_mut(|state| {
+            if let ListenerStatus::Task = State::from(*state).status {
+                // We're still holding onto a task, drop it.
+                task.with_mut(|task| unsafe { ptr::drop_in_place(task.cast::<Task>()) });
+            }
+        });
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct State {
+    /// The status associated with the top-level EventListener.
+    status: ListenerStatus,
+
+    /// The status associated with the queue.
+    queued: bool,
+}
+
+/// The state that a `Listener` can be in.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(usize)]
+enum ListenerStatus {
+    /// The listener was just created.
+    Created,
+
+    /// The listener has been notified through `notify()`.
+    Notified,
+
+    /// The listener has been notified through `notify_additional()`.
+    NotifiedAdditional,
+
+    /// The listener is being used to hold a task.
+    ///
+    /// If the listener is in this state, then the `task` field is guaranteed to
+    /// be initialized.
+    Task,
+
+    /// The `task` field is being written to.
+    WritingTask,
+
+    /// The listener is being dropped.
+    Orphaned,
+}
+
+const LISTENER_STATUS_MASK: usize = 0b1111;
+const QUEUED_SHIFT: usize = 4;
+const QUEUED_MASK: usize = 0b1 << QUEUED_SHIFT;
+
+impl From<usize> for State {
+    fn from(val: usize) -> Self {
+        let status = match val & LISTENER_STATUS_MASK {
+            0 => ListenerStatus::Created,
+            1 => ListenerStatus::Notified,
+            2 => ListenerStatus::NotifiedAdditional,
+            3 => ListenerStatus::Task,
+            4 => ListenerStatus::WritingTask,
+            5 => ListenerStatus::Orphaned,
+            _ => unreachable!("invalid state"),
+        };
+
+        let queued = (val & QUEUED_MASK) != 0;
+
+        Self { status, queued }
+    }
+}
+
+impl From<State> for usize {
+    fn from(state: State) -> Self {
+        let status = state.status as usize;
+        let queued = if state.queued { QUEUED_MASK } else { 0 };
+
+        status | queued
+    }
+}
+
+/// The task to wake up once a notification is received.
+pub(crate) enum Task {
+    /// The task is an async task waiting on a `Waker`.
+    Waker(Waker),
+
+    /// The task is a thread blocked on the `Unparker`.
+    #[cfg(feature = "std")]
+    Thread(Unparker),
+}
+
+impl Task {
+    fn wake(self) {
+        match self {
+            Self::Waker(waker) => waker.wake(),
+            #[cfg(feature = "std")]
+            Self::Thread(unparker) => {
+                unparker.unpark();
+            }
+        }
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,81 @@
+#[cfg(not(loom))]
+mod sync_impl {
+    pub(crate) use core::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
+
+    #[cfg(feature = "std")]
+    pub(crate) use parking::{pair, Unparker};
+
+    pub(crate) trait AtomicWithMut {
+        type Item;
+
+        fn with_mut<R, F: FnOnce(&mut Self::Item) -> R>(&mut self, f: F) -> R;
+    }
+
+    impl AtomicWithMut for AtomicUsize {
+        type Item = usize;
+
+        fn with_mut<R, F: FnOnce(&mut Self::Item) -> R>(&mut self, f: F) -> R {
+            f(self.get_mut())
+        }
+    }
+
+    impl<T> AtomicWithMut for AtomicPtr<T> {
+        type Item = *mut T;
+
+        fn with_mut<R, F: FnOnce(&mut Self::Item) -> R>(&mut self, f: F) -> R {
+            f(self.get_mut())
+        }
+    }
+
+    pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
+
+    impl<T> UnsafeCell<T> {
+        pub(crate) const fn new(item: T) -> Self {
+            Self(core::cell::UnsafeCell::new(item))
+        }
+
+        pub(crate) fn with_mut<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(*mut T) -> R,
+        {
+            f(self.0.get())
+        }
+    }
+}
+
+#[cfg(loom)]
+mod sync_impl {
+    pub(crate) use loom::cell::UnsafeCell;
+    pub(crate) use loom::sync::atomic::{
+        fence, AtomicBool, AtomicPtr, AtomicU32, AtomicUsize, Ordering,
+    };
+
+    /// Re-implementation of `parking::pair` based on loom.
+    pub(crate) fn pair() -> (Parker, Unparker) {
+        let th = loom::thread::current();
+
+        (Parker(Default::default()), Unparker(th))
+    }
+
+    /// Re-implementation of `parking::Parker` based on loom.
+    pub(crate) struct Parker(core::marker::PhantomData<*mut ()>);
+
+    impl Parker {
+        pub(crate) fn park(&self) {
+            loom::thread::park();
+        }
+
+        // park_timeout is not available in loom
+    }
+
+    /// Re-implementation of `parking::Unparker` based on loom.
+    pub(crate) struct Unparker(loom::thread::Thread);
+
+    impl Unparker {
+        pub(crate) fn unpark(&self) {
+            self.0.unpark();
+        }
+    }
+}
+
+pub(crate) use sync_impl::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -46,9 +46,7 @@ mod sync_impl {
 #[cfg(loom)]
 mod sync_impl {
     pub(crate) use loom::cell::UnsafeCell;
-    pub(crate) use loom::sync::atomic::{
-        fence, AtomicBool, AtomicPtr, AtomicU32, AtomicUsize, Ordering,
-    };
+    pub(crate) use loom::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
 
     /// Re-implementation of `parking::pair` based on loom.
     pub(crate) fn pair() -> (Parker, Unparker) {
@@ -69,6 +67,7 @@ mod sync_impl {
     }
 
     /// Re-implementation of `parking::Unparker` based on loom.
+    #[derive(Clone)]
     pub(crate) struct Unparker(loom::thread::Thread);
 
     impl Unparker {
@@ -76,6 +75,9 @@ mod sync_impl {
             self.0.unpark();
         }
     }
+
+    #[allow(dead_code)]
+    pub(crate) trait AtomicWithMut {}
 }
 
 pub(crate) use sync_impl::*;

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,290 @@
+#![cfg(loom)]
+
+use concurrent_queue::{ConcurrentQueue, PopError, PushError};
+use event_listener::{Event, EventListener};
+use loom::cell::UnsafeCell;
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use loom::sync::Arc;
+use loom::thread;
+use std::ops;
+
+/// A basic MPMC channel based on a ConcurrentQueue, Event, and loom primitives.
+struct Channel<T> {
+    /// The queue used to contain items.
+    queue: ConcurrentQueue<T>,
+
+    /// The number of senders.
+    senders: AtomicUsize,
+
+    /// The number of receivers.
+    receivers: AtomicUsize,
+
+    /// The event that is signaled when a new item is pushed.
+    push_event: Event,
+
+    /// The event that is signaled when a new item is popped.
+    pop_event: Event,
+}
+
+/// The sending side of a channel.
+struct Sender<T> {
+    /// The channel.
+    channel: Arc<Channel<T>>,
+}
+
+/// The receiving side of a channel.
+struct Receiver<T> {
+    /// The channel.
+    channel: Arc<Channel<T>>,
+}
+
+/// Create a new pair of senders/receivers based on a queue.
+fn pair<T>() -> (Sender<T>, Receiver<T>) {
+    let channel = Arc::new(Channel {
+        queue: ConcurrentQueue::bounded(10),
+        senders: AtomicUsize::new(1),
+        receivers: AtomicUsize::new(1),
+        push_event: Event::new(),
+        pop_event: Event::new(),
+    });
+
+    (
+        Sender {
+            channel: channel.clone(),
+        },
+        Receiver { channel },
+    )
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        self.channel.senders.fetch_add(1, Ordering::SeqCst);
+        Sender {
+            channel: self.channel.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        if self.channel.senders.fetch_sub(1, Ordering::SeqCst) == 1 {
+            // Close the channel and notify the receivers.
+            self.channel.queue.close();
+            self.channel.push_event.notify_additional(core::usize::MAX);
+        }
+    }
+}
+
+impl<T> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        self.channel.receivers.fetch_add(1, Ordering::SeqCst);
+        Receiver {
+            channel: self.channel.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        if self.channel.receivers.fetch_sub(1, Ordering::SeqCst) == 1 {
+            // Close the channel and notify the senders.
+            self.channel.queue.close();
+            self.channel.pop_event.notify_additional(core::usize::MAX);
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Send a value.
+    ///
+    /// Returns an error with the value if the channel is closed.
+    fn send(&self, mut value: T) -> Result<(), T> {
+        let mut listener = None;
+
+        loop {
+            match self.channel.queue.push(value) {
+                Ok(()) => {
+                    // Notify a single receiver.
+                    self.channel.push_event.notify_additional(1);
+                    return Ok(());
+                }
+                Err(PushError::Closed(val)) => return Err(val),
+                Err(PushError::Full(val)) => {
+                    // Wait for a receiver to pop an item.
+                    match listener.take() {
+                        Some(listener) => listener.wait(),
+                        None => {
+                            listener = Some(self.channel.pop_event.listen());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Receive a value.
+    ///
+    /// Returns an error if the channel is closed.
+    fn recv(&self) -> Result<T, ()> {
+        let mut listener = None;
+
+        loop {
+            match self.channel.queue.pop() {
+                Ok(value) => {
+                    // Notify a single sender.
+                    self.channel.pop_event.notify_additional(1);
+                    return Ok(value);
+                }
+                Err(PopError::Closed) => return Err(()),
+                Err(PopError::Empty) => {
+                    // Wait for a sender to push an item.
+                    match listener.take() {
+                        Some(listener) => listener.wait(),
+                        None => {
+                            listener = Some(self.channel.push_event.listen());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A basic Mutex based on Event and loom primitives.
+struct Mutex<T> {
+    /// The inner value.
+    value: UnsafeCell<T>,
+
+    /// The event that is signaled when the value is unlocked.
+    event: Event,
+
+    /// Is this mutex locked?
+    locked: AtomicBool,
+}
+
+/// A guard that unlocks the mutex when dropped.
+struct MutexGuard<'a, T> {
+    /// The mutex.
+    mutex: &'a Mutex<T>,
+}
+
+impl<T> Mutex<T> {
+    /// Create a new mutex.
+    fn new(value: T) -> Mutex<T> {
+        Mutex {
+            value: UnsafeCell::new(value),
+            event: Event::new(),
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    /// Lock the mutex.
+    fn lock(&self) -> MutexGuard<'_, T> {
+        let mut listener = None;
+
+        loop {
+            match self
+                .locked
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => return MutexGuard { mutex: self },
+                Err(_) => {
+                    // Wait for the mutex to be unlocked.
+                    match listener.take() {
+                        Some(listener) => listener.wait(),
+                        None => {
+                            listener = Some(self.event.listen());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the inner value.
+    fn into_inner(self) -> T {
+        self.value.into_inner()
+    }
+}
+
+impl<'a, T> MutexGuard<'a, T> {
+    fn with<R>(&mut self, f: impl FnOnce(&mut T) -> R) -> R {
+        f(unsafe { &mut *self.mutex.value.get() })
+    }
+}
+
+impl<T> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.mutex.locked.store(false, Ordering::SeqCst);
+        self.mutex.event.notify(1);
+    }
+}
+
+#[test]
+fn spsc() {
+    loom::model(|| {
+        // Create a new pair of senders/receivers.
+        let (tx, rx) = pair();
+
+        // Push each onto a thread and run them.
+        let handle = thread::spawn(move || {
+            for i in 0..limit {
+                if tx.send(i).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut recv_values = vec![];
+
+        loop {
+            match rx.recv() {
+                Ok(value) => recv_values.push(value),
+                Err(()) => break,
+            }
+        }
+
+        // Values may not be in order.
+        recv_values.sort_unstable();
+        assert_eq!(recv_values, (0..limit).collect::<Vec<_>>());
+
+        // Join the handle before we exit.
+        handle.join().unwrap();
+    });
+}
+
+#[test]
+fn contended_mutex() {
+    loom::model(|| {
+        // Create a new mutex.
+        let mutex = Arc::new(Mutex::new(0));
+
+        // Create a bunch of threads that increment the mutex.
+        let mut handles = vec![];
+        let num_threads = loom::MAX_THREADS - 1;
+
+        for _ in 0..num_threads {
+            let mutex = mutex.clone();
+            let handle = thread::spawn(move || {
+                let mut mutex = mutex.lock();
+                mutex.with(|val| {
+                    *val += 1;
+                });
+            });
+            handles.push(handle);
+        }
+
+        // Join the handles.
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // The mutex should have the correct value.
+        let value = Arc::try_unwrap(mutex)
+            .unwrap_or_else(|_| panic!("mutex is locked"))
+            .into_inner();
+        assert_eq!(value, num_threads);
+    });
+}


### PR DESCRIPTION
This PR resolves #28 by replacing this crate's algorithm with one that is compatible with `no_std`. I realized that the current algorithm is basically a concurrent queue, so I replaced it with our `concurrent_queue` crate. The underlying implementation is basically the same, but there is a new `std` feature that prevents `parking` primitives from being used. This is a breaking change, since removing the `std` feature removes the `wait_*` family of functions.

For now, this is a draft PR because:

- I'm waiting for the changes I made to `concurrent_queue` to be released; right now I'm just using ~~master~~ the branch where I'm implementing Loom support.
- ~~The new implementation pasts the existing tests, but I'd like to check to see if it also passes the tests for `async-channel` and `async-lock` when it is patched in.~~ Test suites pass when I patch in this new version of `event-listener`.
- ~~There's a merge conflict I don't feel like resolving right now.~~ Should be fixed by now.
- ~~I'd like to benchmark the changes before I merge them. The new algorithm may allocate more often than the older algorithm. Although this allocation will likely be amortized over the program's runtime, I'd like to be sure that it doesn't impact performance significantly. See #31.~~ See my comment below.
- I also implemented partial support for `loom` testing, but I haven't gotten around to writing the tests for that yet.

Future considerations:

- Since `ConcurrentQueue::bounded()` is more efficient than `ConcurrentQueue::unbounded()`, it may be useful to provide a "with maximum length" method that allocates everything up front.