### PR TITLE
Implement an algorithm to make this crate no_std, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,13 @@ keywords = ["condvar", "eventcount", "wake", "blocking", "park"]
 categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
+[features]
+default = ["std"]
+std = ["parking"]
+
 [dependencies]
-parking = "2.0.0"
+crossbeam-utils = { version = "0.8.12", default-features = false }
+parking = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,6 +511,7 @@ impl EventListener {
             } {
                 // We've been notified, so we're done.
                 self.decrement_length();
+                self.decrement_notified();
                 return true;
             }
 
@@ -606,7 +607,7 @@ impl EventListener {
 
             // If the listener was notified, update the counts.
             if let Some(additional) = orphan {
-                self.inner.notified.fetch_sub(1, Ordering::Release);
+                self.decrement_notified();
                 return Some(additional);
             }
         }
@@ -617,6 +618,11 @@ impl EventListener {
     /// Decrement the length of the queue.
     fn decrement_length(&self) {
         self.inner.len.fetch_sub(1, Ordering::Release);
+    }
+
+    /// Decrement the number of notified listeners.
+    fn decrement_notified(&self) {
+        self.inner.notified.fetch_sub(1, Ordering::Release);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 //! }
 //! ```
 
+#![allow(unused_unsafe)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![no_std]
 

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,410 @@
+//! A listener in the queue of listeners.
+
+use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::cell::Cell;
+
+use core::task::Waker;
+
+#[cfg(feature = "std")]
+use parking::Unparker;
+
+/// A listener in the queue of listeners.
+pub(crate) struct Listener {
+    /// The current state of this listener.
+    ///
+    /// This also serves as the refcount:
+    /// - Ref 1: The listener state is not orphaned.
+    /// - Ref 2: The listener is in the queue (queue bit is set).
+    state: AtomicUsize,
+
+    /// The waker or thread handle that will be notified when the listener is
+    /// ready.
+    ///
+    /// This is kept synchronized by the `state` variable; therefore, it's
+    /// technically `Sync`.
+    waker: Cell<Wakeup>,
+}
+
+impl Listener {
+    /// Create a new listener.
+    pub(crate) fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(
+                State {
+                    listen: ListenState::Created,
+                    queued: false,
+                }
+                .into(),
+            ),
+            waker: Cell::new(Wakeup::None),
+        }
+    }
+
+    /// Enqueue this listener.
+    pub(crate) fn enqueue(&self) {
+        let mut state = State::from(self.state.load(Ordering::Acquire));
+
+        // If the listener is already queued, then we don't need to do anything.
+        loop {
+            if state.queued {
+                return;
+            }
+
+            // Mark the listener as queued.
+            let new_state = State {
+                queued: true,
+                ..state
+            };
+
+            match self.state.compare_exchange(
+                state.into(),
+                new_state.into(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(actual) => state = State::from(actual),
+            }
+        }
+    }
+
+    /// Dequeue this listener.
+    ///
+    /// Returns `true` if the listener is also orphaned, and that the caller
+    /// should drop the listener.
+    pub(crate) fn dequeue(&self) -> bool {
+        let mut state = State::from(self.state.load(Ordering::Acquire));
+
+        // If the listener is not queued, then we don't need to do anything.
+        loop {
+            if !state.queued {
+                return false;
+            }
+
+            // Mark the listener as not queued.
+            let new_state = State {
+                queued: false,
+                ..state
+            };
+
+            match self.state.compare_exchange(
+                state.into(),
+                new_state.into(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(actual) => state = State::from(actual),
+            }
+        }
+
+        // If the listener is orphaned, then we need to drop it.
+        state.listen == ListenState::Orphaned
+    }
+
+    /// Orphan this listener, and return `true` if we need to be dropped.
+    ///
+    /// This method is called when `EventListener` is dropped. The second result is whether or not
+    /// the listener was notified (and `true` if the notification was additional.)
+    pub(crate) fn orphan(&self) -> (bool, Option<bool>) {
+        let mut state = State::from(self.state.load(Ordering::Acquire));
+
+        loop {
+            match state.listen {
+                ListenState::Orphaned => {
+                    // If the listener is already orphaned, then we don't need to do
+                    // anything.
+                    return (false, None);
+                }
+                ListenState::SettingWaker => {
+                    // We may be in the middle of being notified. Wait for the
+                    // notification to complete.
+                    crate::yield_now();
+                    state = State::from(self.state.load(Ordering::Acquire));
+                    continue;
+                }
+                _ => {}
+            }
+
+            // Mark the listener as orphaned.
+            let new_state = State {
+                listen: ListenState::Orphaned,
+                ..state
+            };
+
+            match self.state.compare_exchange(
+                state.into(),
+                new_state.into(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    break;
+                }
+                Err(actual) => state = State::from(actual),
+            }
+        }
+
+        // Determine if we were woken before we were orphaned.
+        let notified = match state.listen {
+            ListenState::Notified => Some(false),
+            ListenState::NotifiedAdditional => Some(true),
+            ListenState::Registered => {
+                // Make sure to delete the waker.
+                self.waker.replace(Wakeup::None);
+
+                None
+            }
+            _ => None,
+        };
+
+        // If the listener is not queued, then we need to drop it.
+        (!state.queued, notified)
+    }
+
+    /// Check to see if we have been notified yet.
+    ///
+    /// Returns true if we have been notified, and false otherwise.
+    pub(crate) fn register(&self, init: impl FnOnce() -> Wakeup) -> bool {
+        let mut state = State::from(self.state.load(Ordering::Acquire));
+
+        loop {
+            match state.listen {
+                ListenState::Orphaned => {
+                    // We've been orphaned, so there is no way we will be notified.
+                    return false;
+                }
+                ListenState::Created | ListenState::Registered => {
+                    // We are not yet notified, so we need to register the waker.
+                    let new_state = State {
+                        listen: ListenState::SettingWaker,
+                        ..state
+                    };
+
+                    match self.state.compare_exchange(
+                        state.into(),
+                        new_state.into(),
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        Ok(_) => {
+                            // We're the first to register, so we need to set the waker.
+                            self.waker.set(init());
+
+                            // Mark the listener as registered.
+                            let new_state = State {
+                                listen: ListenState::Registered,
+                                ..state
+                            };
+
+                            self.state.store(new_state.into(), Ordering::Release);
+
+                            return false;
+                        }
+                        Err(actual) => {
+                            state = State::from(actual);
+                            continue;
+                        }
+                    }
+                }
+                ListenState::Notified | ListenState::NotifiedAdditional => {
+                    // We've been notified!
+                    return true;
+                }
+                ListenState::SettingWaker => {
+                    // We may be in the middle of being notified. Wait for the
+                    // notification to complete.
+                    crate::yield_now();
+                    state = State::from(self.state.load(Ordering::Acquire));
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Notify this listener.
+    ///
+    /// Returns "true" if the notification did anything.
+    pub(crate) fn notify(&self, additional: bool) -> bool {
+        let mut state = State::from(self.state.load(Ordering::Acquire));
+        let new_listen = if additional {
+            ListenState::NotifiedAdditional
+        } else {
+            ListenState::Notified
+        };
+
+        loop {
+            // Determine what we want the new state to be.
+            let new_state = State {
+                listen: new_listen,
+                ..state
+            };
+
+            match state.listen {
+                ListenState::Notified | ListenState::NotifiedAdditional | ListenState::Orphaned => {
+                    // We're already either notified or orphaned.
+                    return false;
+                }
+                ListenState::Created => {
+                    // They haven't registered a wakeup yet, so register them.
+                    if let Err(actual) = self.state.compare_exchange(
+                        state.into(),
+                        new_state.into(),
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        // We failed to register them, so we need to try again.
+                        crate::yield_now();
+                        state = State::from(actual);
+                        continue;
+                    }
+
+                    return true;
+                }
+                ListenState::Registered => {
+                    let intermediate_state = State {
+                        listen: ListenState::SettingWaker,
+                        ..state
+                    };
+
+                    // We're registered, so we need to wake them up.
+                    if let Err(actual) = self.state.compare_exchange(
+                        state.into(),
+                        intermediate_state.into(),
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        // We failed to lock the waker, try again.
+                        crate::yield_now();
+                        state = State::from(actual);
+                        continue;
+                    }
+
+                    // If a waker panics, set the state to notified anyways.
+                    let _cleanup = Cleanup(|| {
+                        self.state.store(new_state.into(), Ordering::Release);
+                    });
+
+                    // Wake them up.
+                    self.waker.replace(Wakeup::None).wake();
+
+                    return true;
+                }
+                ListenState::SettingWaker => {
+                    // The listener is setting the waker, so we need to wait for them to finish.
+                    crate::yield_now();
+                    state = State::from(self.state.load(Ordering::Acquire));
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+/// The current state of a listener.
+///
+/// This is stored in a `usize` in order to allow it to be used atomically.
+#[derive(Copy, Clone)]
+struct State {
+    /// The current listener state.
+    listen: ListenState,
+
+    /// Whether or not we are queued.
+    queued: bool,
+}
+
+const LISTEN_STATE_MASK: usize = 0b111;
+const QUEUED_BIT: usize = 0b1000;
+
+impl From<usize> for State {
+    fn from(value: usize) -> Self {
+        // Determine the `ListenState`.
+        let listen = match value & LISTEN_STATE_MASK {
+            0 => ListenState::Created,
+            1 => ListenState::Registered,
+            2 => ListenState::SettingWaker,
+            3 => ListenState::Notified,
+            4 => ListenState::NotifiedAdditional,
+            5 => ListenState::Orphaned,
+            _ => unreachable!("invalid state"),
+        };
+
+        // Determine if we are queued.
+        let queued = (value & QUEUED_BIT) != 0;
+
+        Self { listen, queued }
+    }
+}
+
+impl From<State> for usize {
+    fn from(state: State) -> Self {
+        state.listen as usize | (if state.queued { QUEUED_BIT } else { 0 })
+    }
+}
+
+/// The current state of a listener.
+///
+/// This is the portion that matters to the `EventListener` structure.
+#[repr(usize)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum ListenState {
+    /// We've just been created and are not yet registered.
+    Created = 0,
+
+    /// We've been registered with a task.
+    ///
+    /// The `waker` field is initialized when we transition to this state.
+    Registered = 1,
+
+    /// We are currently editing the `waker` field.
+    ///
+    /// When we are in this state, someone is modifying the `waker` field.
+    /// We shouldn't do anything until they're done.
+    SettingWaker = 2,
+
+    /// We have been notified, using the `notify()` function.
+    Notified = 3,
+
+    /// We have been notified, using the `notify_additional()` function.
+    NotifiedAdditional = 4,
+
+    /// The event listener is no longer paying attention to us.
+    ///
+    /// The `EventListener` reference no longer exists. If we are in this state,
+    /// and the `QUEUED` bit is no longer set, we should drop ourselves.
+    Orphaned = 5,
+}
+
+/// A waker or thread handle that will be notified when the listener is ready.
+pub(crate) enum Wakeup {
+    /// No waker or thread handle has been set.
+    None,
+
+    /// A waker has been set.
+    Waker(Waker),
+
+    /// A thread handle has been set.
+    #[cfg(feature = "std")]
+    Thread(Unparker),
+}
+
+impl Wakeup {
+    fn wake(self) {
+        match self {
+            Wakeup::None => {}
+            Wakeup::Waker(waker) => waker.wake(),
+            #[cfg(feature = "std")]
+            Wakeup::Thread(unparker) => {
+                unparker.unpark();
+            }
+        }
+    }
+}
+
+struct Cleanup<F: Fn()>(F);
+
+impl<F: Fn()> Drop for Cleanup<F> {
+    fn drop(&mut self) {
+        (self.0)();
+    }
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -135,6 +135,11 @@ impl ListenerQueue {
                 .compare_exchange(head, next, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
+                // If we just set the head to zero, set the tail to zero as well.
+                if next.is_null() {
+                    self.tail.store(ptr::null_mut(), Ordering::SeqCst);
+                }
+
                 // The head has been updated. Dequeue the old head.
                 let head = unsafe { NonNull::new_unchecked(head) };
                 if unsafe { head.as_ref().listener.dequeue() } {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -175,7 +175,7 @@ impl CachedNode {
         // Try to install a cached node.
         if !self.occupied.swap(true, Ordering::Acquire) {
             // We can now initialize the node.
-            let node_ptr = self.node.get() as *mut Node;
+            let node_ptr = unsafe { (*self.node.get()).as_mut_ptr() };
 
             unsafe {
                 // Initialize the node.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,0 +1,219 @@
+//! The atomic queue containing listeners.
+
+use crate::listener::Listener;
+use crate::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+
+use crossbeam_utils::CachePadded;
+
+use alloc::boxed::Box;
+
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::ptr::{self, NonNull};
+
+/// A queue of listeners.
+///
+/// The operations on this queue that are defined are:
+///
+/// - Insertion at the tail of the list.
+/// - Removal from the head of the list.
+/// - Removing arbitrary elements from the list.
+pub(crate) struct ListenerQueue {
+    /// The head of the queue.
+    head: CachePadded<AtomicPtr<Node>>,
+
+    /// The tail of the queue.
+    tail: CachePadded<AtomicPtr<Node>>,
+
+    /// A single cached node.
+    ///
+    /// In theory, this helps the hot case where only a single listener is
+    /// registered. In practice, I don't see much of a difference in benchmarks
+    /// with or without this.
+    cache: CachedNode,
+}
+
+// Ensure the bottom bits of the pointers are not used.
+#[repr(align(4))]
+pub(crate) struct Node {
+    /// The listener in this node.
+    listener: Listener,
+
+    /// The next node in the queue.
+    next: AtomicPtr<Node>,
+}
+
+/// A single cached node.
+struct CachedNode {
+    /// Whether or not the cache is occupied.
+    occupied: AtomicBool,
+
+    /// The cached node.
+    node: UnsafeCell<MaybeUninit<Node>>,
+}
+
+impl ListenerQueue {
+    /// Creates a new, empty queue.
+    pub(crate) fn new() -> Self {
+        Self {
+            head: CachePadded::new(AtomicPtr::new(ptr::null_mut())),
+            tail: CachePadded::new(AtomicPtr::new(ptr::null_mut())),
+            cache: CachedNode {
+                occupied: AtomicBool::new(false),
+                node: UnsafeCell::new(MaybeUninit::uninit()),
+            },
+        }
+    }
+
+    /// Push a new node onto the queue.
+    ///
+    /// Returns a node pointer.
+    pub(crate) fn push(&self, listener: Listener) -> NonNull<Node> {
+        // Allocate a new node.
+        let node = self.alloc(listener);
+
+        loop {
+            // Get the pointer to the node.
+            let tail = self.tail.load(Ordering::Acquire);
+
+            // If the tail is empty, the list has to be empty.
+            let next_ptr = if tail.is_null() {
+                &self.head
+            } else {
+                unsafe { &(*tail).next }
+            };
+
+            // Try to set the next pointer.
+            let next = next_ptr
+                .compare_exchange(
+                    ptr::null_mut(),
+                    node.as_ptr(),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .unwrap_or_else(|x| x);
+
+            // See if the operation succeeded.
+            if next.is_null() {
+                // The node has been added, update the current tail.
+                // If this fails, it means that another node already added themselves as the tail, which probably means
+                // that they are the tail.
+                self.tail
+                    .compare_exchange(tail, node.as_ptr(), Ordering::AcqRel, Ordering::Acquire)
+                    .ok();
+
+                // Make sure the node knows it's enqueued.
+                unsafe {
+                    node.as_ref().listener.enqueue();
+                }
+
+                return node;
+            } else {
+                // The node has not been added, try again.
+                continue;
+            }
+        }
+    }
+
+    /// Pop a node from the queue.
+    pub(crate) fn pop(&self) -> Option<NonNull<Node>> {
+        loop {
+            // Get the head of the queue.
+            let head = self.head.load(Ordering::Acquire);
+
+            // If the head is null, the queue is empty.
+            if head.is_null() {
+                return None;
+            }
+
+            // Get the next pointer.
+            let next = unsafe { (*head).next.load(Ordering::Acquire) };
+
+            // Try to set the head to the next pointer.
+            if self
+                .head
+                .compare_exchange(head, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                // The head has been updated. Dequeue the old head.
+                let head = unsafe { NonNull::new_unchecked(head) };
+                if unsafe { head.as_ref().listener.dequeue() } {
+                    // The EventListener for this node has been dropped, free the node.
+                    unsafe { self.dealloc(head) };
+                } else {
+                    // The event is still in use, return the node.
+                    return Some(head);
+                }
+            }
+        }
+    }
+
+    /// Orphan a node in the queue.
+    ///
+    /// The return value is Some if the node was notified, and true is the notification
+    /// was an additional notification.
+    pub(crate) unsafe fn orphan(&self, node: NonNull<Node>) -> Option<bool> {
+        let (needs_drop, notified) = unsafe { node.as_ref().listener.orphan() };
+
+        // If we need to deallocate the node, do so.
+        if needs_drop {
+            unsafe { self.dealloc(node) };
+        }
+
+        notified
+    }
+
+    /// Allocate a new node for a listener.
+    fn alloc(&self, listener: Listener) -> NonNull<Node> {
+        // Try to install a cached node.
+        if !self.cache.occupied.swap(true, Ordering::Acquire) {
+            // We can now initialize the node.
+            let node_ptr = self.cache.node.get() as *mut Node;
+
+            unsafe {
+                // Initialize the node.
+                node_ptr.write(Node::new(listener));
+
+                // Return the node.
+                NonNull::new_unchecked(node_ptr)
+            }
+        } else {
+            // We failed to install a cached node, so we need to allocate a new
+            // one.
+            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(Node::new(listener)))) }
+        }
+    }
+
+    /// Deallocate a node.
+    unsafe fn dealloc(&self, node: NonNull<Node>) {
+        // Is this node the current cache node?
+        if ptr::eq(self.cache.node.get() as *const Node, node.as_ptr()) {
+            // We can now clear the cache.
+            unsafe { (self.cache.node.get() as *mut Node).drop_in_place() };
+            self.cache.occupied.store(false, Ordering::Release);
+        } else {
+            // We need to deallocate the node on the heap.
+            unsafe { Box::from_raw(node.as_ptr()) };
+        }
+    }
+}
+
+impl Node {
+    fn new(listener: Listener) -> Self {
+        Self {
+            listener,
+            next: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+
+    pub(crate) fn listener(&self) -> &Listener {
+        &self.listener
+    }
+}
+
+impl Drop for ListenerQueue {
+    fn drop(&mut self) {
+        // Drain the queue.
+        while self.pop().is_some() {}
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,60 @@
+//! The current implementation of synchronization primitives.
+
+// TODO: Add implementations for portable_atomic and loom.
+
+mod sync_impl {
+    pub(crate) use alloc::sync::Arc;
+    pub(crate) use core::cell;
+    pub(crate) use core::sync::atomic;
+
+    pub(crate) trait AtomicWithMut {
+        type Target;
+
+        fn with_mut<F, R>(&mut self, f: F) -> R
+        where
+            F: FnOnce(&mut Self::Target) -> R;
+    }
+
+    impl<T> AtomicWithMut for atomic::AtomicPtr<T> {
+        type Target = *mut T;
+
+        fn with_mut<F, R>(&mut self, f: F) -> R
+        where
+            F: FnOnce(&mut Self::Target) -> R,
+        {
+            f(self.get_mut())
+        }
+    }
+
+    impl AtomicWithMut for atomic::AtomicUsize {
+        type Target = usize;
+
+        fn with_mut<F, R>(&mut self, f: F) -> R
+        where
+            F: FnOnce(&mut Self::Target) -> R,
+        {
+            f(self.get_mut())
+        }
+    }
+
+    pub(crate) trait CellWithMut {
+        type Target;
+
+        fn with_mut<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(*mut Self::Target) -> R;
+    }
+
+    impl<T> CellWithMut for cell::UnsafeCell<T> {
+        type Target = T;
+
+        fn with_mut<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(*mut Self::Target) -> R,
+        {
+            f(self.get())
+        }
+    }
+}
+
+pub(crate) use sync_impl::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,83 @@
+//! Various utility structures.
+
+use crate::sync::atomic::{AtomicPtr, Ordering};
+use crate::sync::{Arc, AtomicWithMut};
+
+use core::mem::ManuallyDrop;
+use core::ptr;
+
+/// A wrapper around an `Arc` that is initialized atomically in a racy manner.
+#[derive(Default)]
+pub(crate) struct RacyArc<T> {
+    ptr: AtomicPtr<T>,
+}
+
+unsafe impl<T: Send + Sync> Send for RacyArc<T> {}
+unsafe impl<T: Send + Sync> Sync for RacyArc<T> {}
+
+impl<T> RacyArc<T> {
+    /// Create a new, empty `RacyArc`.
+    pub(crate) const fn new() -> Self {
+        Self {
+            ptr: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+
+    /// Try to load the inner `T` or return `None` if it is not initialized.
+    pub(crate) fn get(&self) -> Option<&T> {
+        let ptr = self.ptr.load(Ordering::Acquire);
+
+        // SAFETY: `ptr` is either a valid `T` reference or `null_mut()`.
+        unsafe { ptr.as_ref() }
+    }
+
+    /// Load the inner `T`, initializing it using the given closure if it is not
+    /// initialized.
+    pub(crate) fn get_or_init(&self, init: impl FnOnce() -> Arc<T>) -> ManuallyDrop<Arc<T>> {
+        let mut ptr = self.ptr.load(Ordering::Acquire);
+
+        if ptr.is_null() {
+            // Initialize the `Arc` using the given closure.
+            let data = init();
+
+            // Convert it to a pointer.
+            let new = Arc::into_raw(data) as *mut T;
+
+            // Try to swap the pointer.
+            ptr = self
+                .ptr
+                .compare_exchange(ptr, new, Ordering::AcqRel, Ordering::Acquire)
+                .unwrap_or_else(|x| x);
+
+            // Check if the pointer we tried to replace is null.
+            if ptr.is_null() {
+                // If it is, we successfully initialized the `RacyArc`.
+                ptr = new;
+            } else {
+                // If it is not, we failed to initialize the `RacyArc` and we
+                // need to drop the `Arc` we created.
+                drop(unsafe { Arc::from_raw(new) });
+            }
+        }
+
+        // SAFETY: `ptr` is now a valid T reference.
+        ManuallyDrop::new(unsafe { Arc::from_raw(ptr) })
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.ptr.load(Ordering::Acquire)
+    }
+}
+
+impl<T> Drop for RacyArc<T> {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` is either `null` or a valid `Arc<T>` reference.
+        self.ptr.with_mut(|ptr| {
+            if !ptr.is_null() {
+                unsafe {
+                    Arc::from_raw(*ptr);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
I'm not satisfied with the direction #30 has taken, so I've written this PR. It's less destructive, less verbose, and faster than the previous one. I haven't implemented `portable_atomic` or `loom` support here, I'll do that in future PRs.

In this PR, rather than using a `Mutex` to wrap an unsync linked list (what's currently on `master`) or using `ConcurrentQueue` (as in #30), I use an atomic singly linked list to store listeners. Similarly to #30, listeners in this list can be marked as "orphaned" to indicate that they should not be notified (e.g. when the `EventListener` is dropped). As opposed to #30, it only exhibits a 20% slowdown as compared to `master` on my PC. With the increased number of atomic operations involved, I think that that is about as low as we can go without using a locking mechanism of some kind.

Future work:

- Add `portable_atomic` and `loom` support.
- It may be possible to write this crate using only safe code. I intentionally separated out `RacyArc` because we may be able to split it off into another crate, the interior mutability in `Listener` can be resolved using `crossbeam_utils::AtomicCell<Wakeup>` or similar, and the linked list could probably be emulated using `AtomicCell` and `Arc` as well. The main concern is that we would have to not use the cache in `ListenerQueue`, and this (among other things) would likely cause significant performance issues (`Arc` is expensive).
- Another way of doing this is using a spinlock, but making sure we never actually spin on it. We keep the `master` branch, but replace the `Mutex` with a spinlock. `notify` and `listen` both try to access the spinlock. If `notify` sees the spinlock active, it places the notification counts in an atomic variable and whoever holds the spinlock preforms the notification once they're about the drop the lock. If `listen` (or any of `EventListener`'s methods) see the spinlock locked, they put their `Waker`s (or `Unparker`s) into a short-term `ConcurrentQueue` which is then used to set up listeners once the current holder tries to drop the lock. This may be a better way of doing it, but I don't know whether it would be faster or slower.