### PR TITLE
Replace the linked list with a safer and less allocation-heavy alternative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ __test = []
 [dependencies]
 crossbeam-utils = { version = "0.8.12", default-features = false }
 parking = { version = "2.0.0", optional = true }
+slab = { version = "0.4.7", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -208,3 +208,6 @@ impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
         unsafe { &mut *self.mutex.value.get() }
     }
 }
+
+unsafe impl<T: Send> Send for Mutex<T> {}
+unsafe impl<T: Send> Sync for Mutex<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,6 @@ pub struct Event {
     inner: AtomicPtr<Inner>,
 }
 
-unsafe impl Send for Event {}
-unsafe impl Sync for Event {}
-
 #[cfg(feature = "std")]
 impl UnwindSafe for Event {}
 #[cfg(feature = "std")]
@@ -532,9 +529,6 @@ pub struct EventListener {
     /// The current state of the listener.
     state: ListenerState,
 }
-
-unsafe impl Send for EventListener {}
-unsafe impl Sync for EventListener {}
 
 enum ListenerState {
     /// The listener has a node inside of the linked list.

--- a/src/list.rs
+++ b/src/list.rs
@@ -93,11 +93,11 @@ impl List {
     /// Inserts a new entry into the list.
     pub(crate) fn insert(&mut self, entry: Entry) -> NonZeroUsize {
         // Replace the tail with the new entry.
-        let key = NonZeroUsize::new(self.entries.vacant_key());
-        match mem::replace(&mut self.tail, key) {
-            None => self.head = key,
+        let key = NonZeroUsize::new(self.entries.vacant_key()).unwrap();
+        match mem::replace(&mut self.tail, Some(key)) {
+            None => self.head = Some(key),
             Some(t) => {
-                self.entries[t.get()].next.set(key);
+                self.entries[t.get()].next.set(Some(key));
                 entry.prev.set(Some(t));
             }
         }
@@ -111,7 +111,7 @@ impl List {
         self.entries.insert(entry);
 
         // Return the key.
-        key.unwrap()
+        key
     }
 
     /// Removes an entry from the list and returns its state.

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,11 +1,12 @@
 //! The node that makes up queues.
 
-use crate::inner::Inner;
 use crate::list::{Entry, List, State};
+use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::Arc;
 use crate::{Notify, NotifyKind, Task};
 
-use alloc::boxed::Box;
-use core::ptr::NonNull;
+use core::num::NonZeroUsize;
+use crossbeam_utils::atomic::AtomicCell;
 
 /// A node in the backup queue.
 pub(crate) enum Node {
@@ -13,8 +14,8 @@ pub(crate) enum Node {
     // For some reason, the MSRV build says this variant is never constructed.
     #[allow(dead_code)]
     AddListener {
-        /// The pointer to the listener to add.
-        listener: Option<DistOwnedListener>,
+        /// The state of the listener that wants to be added.
+        task_waiting: Arc<TaskWaiting>,
     },
 
     /// This node is notifying a listener.
@@ -22,8 +23,8 @@ pub(crate) enum Node {
 
     /// This node is removing a listener.
     RemoveListener {
-        /// The pointer to the listener to remove.
-        listener: NonNull<Entry>,
+        /// The ID of the listener to remove.
+        listener: NonZeroUsize,
 
         /// Whether to propagate notifications to the next listener.
         propagate: bool,
@@ -33,54 +34,43 @@ pub(crate) enum Node {
     Waiting(Task),
 }
 
-pub(crate) struct DistOwnedListener(NonNull<Entry>);
+pub(crate) struct TaskWaiting {
+    /// The task that is being waited on.
+    task: AtomicCell<Option<Task>>,
 
-impl DistOwnedListener {
-    /// extracts the contained entry pointer from the DOL,
-    /// without calling the DOL Drop handler (such that the returned pointer stays valid)
-    fn take(self) -> NonNull<Entry> {
-        core::mem::ManuallyDrop::new(self).0
-    }
-}
-
-impl Drop for DistOwnedListener {
-    fn drop(&mut self) {
-        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
-    }
+    /// The ID of the new entry.
+    ///
+    /// This is set to zero when the task is still queued.
+    entry_id: AtomicUsize,
 }
 
 impl Node {
-    pub(crate) fn listener() -> (Self, NonNull<Entry>) {
-        let entry = Box::into_raw(Box::new(Entry::new()));
-        let entry = unsafe { NonNull::new_unchecked(entry) };
+    pub(crate) fn listener() -> (Self, Arc<TaskWaiting>) {
+        // Create a new `TaskWaiting` structure.
+        let task_waiting = Arc::new(TaskWaiting {
+            task: AtomicCell::new(None),
+            entry_id: AtomicUsize::new(0),
+        });
+
         (
             Self::AddListener {
-                listener: Some(DistOwnedListener(entry)),
+                task_waiting: task_waiting.clone(),
             },
-            entry,
+            task_waiting,
         )
     }
 
-    /// Indicate that this node has been enqueued.
-    pub(crate) fn enqueue(&self) {
-        if let Node::AddListener {
-            listener: Some(entry),
-        } = self
-        {
-            unsafe { entry.0.as_ref() }.enqueue();
-        }
-    }
-
     /// Apply the node to the list.
-    pub(crate) fn apply(self, list: &mut List, inner: &Inner) -> Option<Task> {
+    pub(crate) fn apply(self, list: &mut List) -> Option<Task> {
         match self {
-            Node::AddListener { mut listener } => {
-                // Add the listener to the list.
-                let entry = listener.take().unwrap().take();
-                list.insert(entry);
+            Node::AddListener { task_waiting } => {
+                // Add a new entry to the list.
+                let entry = Entry::new();
+                let key = list.insert(entry);
 
-                // Dequeue the listener.
-                return unsafe { entry.as_ref().dequeue() };
+                // Send the new key to the listener and wake it if necessary.
+                task_waiting.entry_id.store(key.get(), Ordering::Release);
+                return task_waiting.task.take();
             }
             Node::Notify(Notify { count, kind }) => {
                 // Notify the listener.
@@ -94,7 +84,7 @@ impl Node {
                 propagate,
             } => {
                 // Remove the listener from the list.
-                let state = list.remove(listener, inner.cache_ptr());
+                let state = list.remove(listener);
 
                 if let (true, State::Notified(additional)) = (propagate, state) {
                     // Propagate the notification to the next listener.
@@ -107,5 +97,26 @@ impl Node {
         }
 
         None
+    }
+}
+
+impl TaskWaiting {
+    /// Determine if we are still queued.
+    ///
+    /// Returns `Some` with the entry ID if we are no longer queued.
+    pub(crate) fn status(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(self.entry_id.load(Ordering::Acquire))
+    }
+
+    /// Register a listener.
+    pub(crate) fn register(&self, task: Task) {
+        // Set the task.
+        self.task.store(Some(task));
+
+        // If the entry ID is non-zero, then we are no longer queued.
+        if self.status().is_some() {
+            // Wake the task.
+            self.task.take().unwrap().wake();
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -111,7 +111,9 @@ impl TaskWaiting {
     /// Register a listener.
     pub(crate) fn register(&self, task: Task) {
         // Set the task.
-        self.task.store(Some(task));
+        if let Some(task) = self.task.swap(Some(task)) {
+            task.wake();
+        }
 
         // If the entry ID is non-zero, then we are no longer queued.
         if self.status().is_some() {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -37,7 +37,6 @@ impl Queue {
 
     /// Push a node to the tail end of the queue.
     pub(crate) fn push(&self, node: Node) {
-        node.enqueue();
         let node = Box::into_raw(Box::new(QueueNode {
             next: AtomicPtr::new(ptr::null_mut()),
             node,

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -134,13 +134,13 @@ fn drop_non_notified() {
     let event = Event::new();
 
     let mut l1 = event.listen();
-    //let mut l2 = event.listen();
+    let mut l2 = event.listen();
     let l3 = event.listen();
 
     event.notify(1);
     drop(l3);
     assert!(is_notified(&mut l1));
-    //assert!(!is_notified(&mut l2));
+    assert!(!is_notified(&mut l2));
 }
 
 #[test]


### PR DESCRIPTION
Right now, the current algorithm on `master` uses a linked list to implement the queue of listeners that powers the `Event` structure. The allocation scheme for this linked list is relatively naive and unsafe. In the fast case, it writes to an `UnsafeCell` cache entry inside the `Event`'s allocation proper. In the slow case, it allocates (and then deallocates) a `Box` heap allocation containing the `Entry`.

This PR replaces it with an algorithm that is both safer and more efficient. It adds the `slab` crate as a dependency and uses that to store the `Entry`s. In addition, to keep track of the `Entry`s, this crate no longer stores `NonNull<Entry>`s, but instead the index of the `Entry` in the `Slab`. This strategy allows us to eliminate a significant amount of unsafe code.

I've also modified the `Node` code a bit to accommodate this new change. This led to the introduction of a `TaskWaiting` structure that the `Node` uses to communicate with the `EventListener`. This also reduces the amount of unsafe code involved.

Benchmark wise, it's about equal to the current algorithm, plus or minus some level of noise.

![noise](https://i.imgur.com/DRoOyN3.png)

Here are quantitative measures of the unsafe code eliminated:

Current `master`:

![master](https://i.imgur.com/kjGedts.png)

New branch:

![new branch](https://i.imgur.com/256auKG.png)
