### PR TITLE
Replace custom spinlock with spin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ __test = []
 crossbeam-utils = { version = "0.8.12", default-features = false }
 parking = { version = "2.0.0", optional = true }
 slab = { version = "0.4.7", default-features = false }
+spin = { version = "0.9.4", default-features = false, features = ["spin_mutex"] }
 
 [dev-dependencies]
 waker-fn = "1"


### PR DESCRIPTION
This deduplicates the custom spinlock we have with the one that's currently used in the `spin` crate.