### PR TITLE
m: Remove unnecessary dependencies from event-listener-strategy

### DIFF
--- a/strategy/Cargo.toml
+++ b/strategy/Cargo.toml
@@ -13,8 +13,6 @@ exclude = ["/.*"]
 
 [dependencies]
 event-listener = { path = "..", version = "2", default-features = false }
-pin-project-lite = "0.2.9"
-pin-utils = "0.1.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
- We never actually end up using `pin_utils`, it was a mistake to leave that in.
- We can get around `pin_project_lite` by implementing manual pin projection.