### PR TITLE
feat: Add tagged notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ portable-atomic = ["portable-atomic-util", "portable_atomic_crate"]
 
 [dependencies]
 parking = { version = "2.0.0", optional = true }
-portable-atomic-util = { version = "0.1.1", default-features = false, optional = true, features = ["alloc"] }
+portable-atomic-util = { version = "0.1.2", default-features = false, optional = true, features = ["alloc"] }
 
 [dependencies.portable_atomic_crate]
 package = "portable-atomic"

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -90,9 +90,7 @@ impl<T> Mutex<T> {
                 }
                 Some(mut l) => {
                     // Wait until a notification is received.
-                    if !l.as_mut().wait_deadline(deadline) {
-                        return None;
-                    }
+                    l.as_mut().wait_deadline(deadline)?;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@ use std::time::{Duration, Instant};
 use sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use sync::{Arc, WithMut};
 
-pub use notify::{Additional, IntoNotification, Notification, Notify, Tag, TagWith};
+use notify::{Internal, NotificationPrivate};
+pub use notify::{IntoNotification, Notification};
 
 /// Useful traits for notifications.
 pub mod prelude {
@@ -343,13 +344,13 @@ impl<T> Event<T> {
         let notify = notify.into_notification();
 
         // Make sure the notification comes after whatever triggered it.
-        notify.fence();
+        notify.fence(notify::Internal::new());
 
         if let Some(inner) = self.try_inner() {
-            let limit = if notify.is_additional() {
+            let limit = if notify.is_additional(Internal::new()) {
                 core::usize::MAX
             } else {
-                notify.count()
+                notify.count(Internal::new())
             };
 
             // Notify if there is at least one unnotified listener and the number of notified

--- a/src/no_std/node.rs
+++ b/src/no_std/node.rs
@@ -52,7 +52,7 @@ pub(crate) struct TaskWaiting {
     entry_id: AtomicUsize,
 }
 
-impl<T: Unpin> Node<T> {
+impl<T> Node<T> {
     pub(crate) fn listener() -> (Self, Arc<TaskWaiting>) {
         // Create a new `TaskWaiting` structure.
         let task_waiting = Arc::new(TaskWaiting {

--- a/src/no_std/queue.rs
+++ b/src/no_std/queue.rs
@@ -129,7 +129,7 @@ impl<T> Drop for Queue<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::notify::{GenericNotify, Notification};
+    use crate::notify::{GenericNotify, Internal, NotificationPrivate};
 
     use super::*;
 
@@ -139,7 +139,7 @@ mod tests {
 
     fn node_to_num(node: Node<()>) -> usize {
         match node {
-            Node::Notify(notify) => notify.count(),
+            Node::Notify(notify) => notify.count(Internal::new()),
             _ => panic!("unexpected node"),
         }
     }

--- a/src/no_std/queue.rs
+++ b/src/no_std/queue.rs
@@ -130,11 +130,16 @@ impl<T> Drop for Queue<T> {
 #[cfg(test)]
 mod tests {
     use crate::notify::{GenericNotify, Internal, NotificationPrivate};
+    use crate::sys::node::VecProducer;
 
     use super::*;
 
     fn node_from_num(num: usize) -> Node<()> {
-        Node::Notify(GenericNotify::new(num, true, Box::new(|| ())))
+        Node::Notify(GenericNotify::new(
+            num,
+            true,
+            VecProducer(vec![(); num].into_iter()),
+        ))
     }
 
     fn node_to_num(node: Node<()>) -> usize {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -263,7 +263,7 @@ pub(crate) struct GenericNotify<F> {
     tags: F,
 }
 
-impl<T, F: FnMut() -> T> GenericNotify<F> {
+impl<T, F: TagProducer<Tag = T>> GenericNotify<F> {
     pub(crate) fn new(count: usize, additional: bool, tags: F) -> Self {
         Self {
             count,
@@ -273,7 +273,7 @@ impl<T, F: FnMut() -> T> GenericNotify<F> {
     }
 }
 
-impl<T, F: FnMut() -> T> NotificationPrivate for GenericNotify<F> {
+impl<T, F: TagProducer<Tag = T>> NotificationPrivate for GenericNotify<F> {
     type Tag = T;
 
     fn is_additional(&self, _: Internal) -> bool {
@@ -289,7 +289,23 @@ impl<T, F: FnMut() -> T> NotificationPrivate for GenericNotify<F> {
     }
 
     fn next_tag(&mut self, _: Internal) -> Self::Tag {
-        (self.tags)()
+        self.tags.next_tag()
+    }
+}
+
+/// The producer for a generic notification.
+pub(crate) trait TagProducer {
+    type Tag;
+
+    /// Get the next tag.
+    fn next_tag(&mut self) -> Self::Tag;
+}
+
+impl<T, F: FnMut() -> T> TagProducer for F {
+    type Tag = T;
+
+    fn next_tag(&mut self) -> T {
+        (self)()
     }
 }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -323,8 +323,8 @@ macro_rules! impl_for_numeric_types {
             type Tag = ();
             type Notify = Notify;
 
+            #[allow(unused_comparisons)]
             fn into_notification(self) -> Self::Notify {
-                #[allow(unused_comparisons)]
                 if self < 0 {
                     panic!("negative notification count");
                 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -49,7 +49,7 @@ pub trait NotificationPrivate {
 ///     ev.notify(notify);
 /// }
 ///
-/// notify(1.additional());
+/// notify(&Event::new(), 1.additional());
 /// ```
 pub trait Notification: NotificationPrivate {}
 impl<N: NotificationPrivate + ?Sized> Notification for N {}
@@ -413,7 +413,7 @@ pub trait IntoNotification: __private::Sealed {
     /// # Examples
     ///
     /// ```
-    /// use event_listener::Event;
+    /// use event_listener::{Event, prelude::*};
     /// use std::sync::atomic::{self, Ordering};
     ///
     /// let event = Event::new();

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -324,6 +324,11 @@ macro_rules! impl_for_numeric_types {
             type Notify = Notify;
 
             fn into_notification(self) -> Self::Notify {
+                #[allow(unused_comparisons)]
+                if self < 0 {
+                    panic!("negative notification count");
+                }
+
                 use core::convert::TryInto;
                 Notify::new(self.try_into().expect("overflow"))
             }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,300 @@
+//! The `Notification` trait for specifying notification.
+
+use crate::sync::atomic::{self, AtomicUsize, Ordering};
+use core::fmt;
+
+/// The type of notification to use with an [`Event`].
+pub trait Notification {
+    /// The tag data associated with a notification.
+    type Tag;
+
+    /// Emit a fence to ensure that the notification is visible to the
+    /// listeners.
+    fn fence(&self);
+
+    /// Get the number of listeners to wake, given the number of listeners
+    /// that are currently waiting.
+    fn count(&self, waiting: usize) -> usize;
+
+    /// Get a tag to be associated with a notification.
+    ///
+    /// This method is expected to be called `count()` times.
+    fn next_tag(&mut self) -> Self::Tag;
+}
+
+/// Notify a given number of unnotifed listeners.
+#[derive(Debug, Clone)]
+pub struct Notify(usize);
+
+impl Notify {
+    /// Create a new `Notify` with the given number of listeners to notify.
+    fn new(count: usize) -> Self {
+        Self(count)
+    }
+}
+
+impl From<usize> for Notify {
+    fn from(count: usize) -> Self {
+        Self::new(count)
+    }
+}
+
+impl Notification for Notify {
+    type Tag = ();
+
+    fn fence(&self) {
+        full_fence();
+    }
+
+    fn count(&self, waiting: usize) -> usize {
+        self.0.saturating_sub(waiting)
+    }
+
+    fn next_tag(&mut self) -> Self::Tag {}
+}
+
+/// Notify a given number of listeners.
+#[derive(Debug, Clone)]
+pub struct NotifyAdditional(usize);
+
+impl NotifyAdditional {
+    /// Create a new `NotifyAdditional` with the given number of listeners to notify.
+    fn new(count: usize) -> Self {
+        Self(count)
+    }
+}
+
+impl From<usize> for NotifyAdditional {
+    fn from(count: usize) -> Self {
+        Self::new(count)
+    }
+}
+
+impl Notification for NotifyAdditional {
+    type Tag = ();
+
+    fn fence(&self) {
+        full_fence();
+    }
+
+    fn count(&self, _waiting: usize) -> usize {
+        self.0
+    }
+
+    fn next_tag(&mut self) -> Self::Tag {}
+}
+
+/// Don't emit a fence for this notification.
+#[derive(Debug, Clone)]
+pub struct Relaxed<N: ?Sized>(N);
+
+impl<N> Relaxed<N> {
+    /// Create a new `Relaxed` with the given notification.
+    fn new(inner: N) -> Self {
+        Self(inner)
+    }
+}
+
+impl<N> Notification for Relaxed<N>
+where
+    N: Notification + ?Sized,
+{
+    type Tag = N::Tag;
+
+    fn fence(&self) {
+        // Don't emit a fence.
+    }
+
+    fn count(&self, waiting: usize) -> usize {
+        self.0.count(waiting)
+    }
+
+    fn next_tag(&mut self) -> Self::Tag {
+        self.0.next_tag()
+    }
+}
+
+/// Use a tag to notify listeners.
+#[derive(Debug, Clone)]
+pub struct Tag<N: ?Sized, T> {
+    tag: T,
+    inner: N,
+}
+
+impl<N: ?Sized, T> Tag<N, T> {
+    /// Create a new `Tag` with the given tag and notification.
+    fn new(tag: T, inner: N) -> Self
+    where
+        N: Sized,
+    {
+        Self { tag, inner }
+    }
+}
+
+impl<N, T> Notification for Tag<N, T>
+where
+    N: Notification + ?Sized,
+    T: Clone,
+{
+    type Tag = T;
+
+    fn fence(&self) {
+        self.inner.fence();
+    }
+
+    fn count(&self, waiting: usize) -> usize {
+        self.inner.count(waiting)
+    }
+
+    fn next_tag(&mut self) -> Self::Tag {
+        self.tag.clone()
+    }
+}
+
+/// Use a function to generate a tag to notify listeners.
+pub struct TagWith<N: ?Sized, F> {
+    tag: F,
+    inner: N,
+}
+
+impl<N: fmt::Debug, F> fmt::Debug for TagWith<N, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct Ellipses;
+
+        impl fmt::Debug for Ellipses {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("..")
+            }
+        }
+
+        f.debug_struct("TagWith")
+            .field("tag", &Ellipses)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<N, F> TagWith<N, F> {
+    /// Create a new `TagFn` with the given tag function and notification.
+    fn new(tag: F, inner: N) -> Self {
+        Self { tag, inner }
+    }
+}
+
+impl<N, F, T> Notification for TagWith<N, F>
+where
+    N: Notification + ?Sized,
+    F: FnMut() -> T,
+{
+    type Tag = T;
+
+    fn fence(&self) {
+        self.inner.fence();
+    }
+
+    fn count(&self, waiting: usize) -> usize {
+        self.inner.count(waiting)
+    }
+
+    fn next_tag(&mut self) -> Self::Tag {
+        (self.tag)()
+    }
+}
+
+/// A value that can be converted into a [`Notification`].
+pub trait IntoNotification {
+    /// The tag data associated with a notification.
+    type Tag;
+
+    /// The notification type.
+    type Notify: Notification<Tag = Self::Tag>;
+
+    /// Convert this value into a notification.
+    fn into_notification(self) -> Self::Notify;
+
+    /// Convert this value into an additional notification.
+    fn additional(self) -> NotifyAdditional
+    where
+        Self: Sized + IntoNotification<Notify = Notify>,
+    {
+        NotifyAdditional::new(self.into_notification().count(0))
+    }
+
+    /// Don't emit a fence for this notification.
+    fn relaxed(self) -> Relaxed<Self::Notify>
+    where
+        Self: Sized,
+    {
+        Relaxed::new(self.into_notification())
+    }
+
+    /// Use a tag with this notification.
+    fn tag<T: Clone>(self, tag: T) -> Tag<Self::Notify, T>
+    where
+        Self: Sized + IntoNotification<Tag = ()>,
+    {
+        Tag::new(tag, self.into_notification())
+    }
+
+    /// Use a function to generate a tag with this notification.
+    fn tag_with<T, F>(self, tag: F) -> TagWith<Self::Notify, F>
+    where
+        Self: Sized + IntoNotification<Tag = ()>,
+        F: FnMut() -> T,
+    {
+        TagWith::new(tag, self.into_notification())
+    }
+}
+
+impl<N: Notification> IntoNotification for N {
+    type Tag = N::Tag;
+    type Notify = N;
+
+    fn into_notification(self) -> Self::Notify {
+        self
+    }
+}
+
+macro_rules! impl_for_numeric_types {
+    ($($ty:ty)*) => {$(
+        impl IntoNotification for $ty {
+            type Tag = ();
+            type Notify = Notify;
+
+            fn into_notification(self) -> Self::Notify {
+                use core::convert::TryInto;
+                Notify::new(self.try_into().expect("overflow"))
+            }
+        }
+    )*};
+}
+
+impl_for_numeric_types! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+
+/// Equivalent to `atomic::fence(Ordering::SeqCst)`, but in some cases faster.
+#[inline]
+pub(super) fn full_fence() {
+    if cfg!(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(miri)
+    )) {
+        // HACK(stjepang): On x86 architectures there are two different ways of executing
+        // a `SeqCst` fence.
+        //
+        // 1. `atomic::fence(SeqCst)`, which compiles into a `mfence` instruction.
+        // 2. `_.compare_exchange(_, _, SeqCst, SeqCst)`, which compiles into a `lock cmpxchg` instruction.
+        //
+        // Both instructions have the effect of a full barrier, but empirical benchmarks have shown
+        // that the second one is sometimes a bit faster.
+        //
+        // The ideal solution here would be to use inline assembly, but we're instead creating a
+        // temporary atomic variable and compare-and-exchanging its value. No sane compiler to
+        // x86 platforms is going to optimize this away.
+        atomic::compiler_fence(Ordering::SeqCst);
+        let a = AtomicUsize::new(0);
+        let _ = a.compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst);
+        atomic::compiler_fence(Ordering::SeqCst);
+    } else {
+        atomic::fence(Ordering::SeqCst);
+    }
+}

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -221,22 +221,29 @@ where
     }
 }
 
-/// A single notification.
-pub(crate) struct SingleNotify<T> {
+/// A generic notification.
+pub(crate) struct GenericNotify<F> {
+    /// Number of listeners to notify.
+    count: usize,
+
+    /// Whether this notification is additional.
     additional: bool,
-    tag: Option<T>,
+
+    /// Generate tags.
+    tags: F,
 }
 
-impl<T> SingleNotify<T> {
-    pub(crate) fn new(additional: bool, tag: T) -> Self {
+impl<T, F: FnMut() -> T> GenericNotify<F> {
+    pub(crate) fn new(count: usize, additional: bool, tags: F) -> Self {
         Self {
+            count,
             additional,
-            tag: Some(tag),
+            tags,
         }
     }
 }
 
-impl<T> Notification for SingleNotify<T> {
+impl<T, F: FnMut() -> T> Notification for GenericNotify<F> {
     type Tag = T;
 
     fn is_additional(&self) -> bool {
@@ -248,11 +255,11 @@ impl<T> Notification for SingleNotify<T> {
     }
 
     fn count(&self) -> usize {
-        1
+        self.count
     }
 
     fn next_tag(&mut self) -> Self::Tag {
-        self.tag.take().unwrap()
+        (self.tags)()
     }
 }
 

--- a/src/std.rs
+++ b/src/std.rs
@@ -2,7 +2,7 @@
 //!
 //! This implementation crates an intrusive linked list of listeners.
 
-use crate::notify::{GenericNotify, Notification};
+use crate::notify::{GenericNotify, Internal, Notification};
 use crate::sync::atomic::Ordering;
 use crate::sync::cell::{Cell, UnsafeCell};
 use crate::sync::{Mutex, MutexGuard};
@@ -237,8 +237,8 @@ impl<T> Inner<T> {
 
     #[cold]
     fn notify(&mut self, mut notify: impl Notification<Tag = T>) {
-        let mut n = notify.count();
-        let is_additional = notify.is_additional();
+        let mut n = notify.count(Internal::new());
+        let is_additional = notify.is_additional(Internal::new());
 
         if !is_additional {
             if n < self.notified {
@@ -260,7 +260,7 @@ impl<T> Inner<T> {
                     self.next = entry.next.get();
 
                     // Set the state to `Notified` and notify.
-                    let tag = notify.next_tag();
+                    let tag = notify.next_tag(Internal::new());
                     if let State::Task(task) = entry.state.replace(State::Notified {
                         additional: is_additional,
                         tag,

--- a/strategy/src/lib.rs
+++ b/strategy/src/lib.rs
@@ -337,11 +337,11 @@ pub trait Strategy<'a> {
     type Future: Future + 'a;
 
     /// Poll the event listener until it is ready.
-    fn poll(
+    fn poll<T>(
         &mut self,
-        event_listener: Pin<&mut EventListener>,
+        event_listener: Pin<&mut EventListener<T>>,
         context: &mut Self::Context,
-    ) -> Poll<()>;
+    ) -> Poll<T>;
 
     /// Wait for the event listener to become ready.
     fn wait(&mut self, evl: Pin<&'a mut EventListener>) -> Self::Future;
@@ -363,11 +363,11 @@ impl<'a, 'evl> Strategy<'evl> for NonBlocking<'a> {
     }
 
     #[inline]
-    fn poll(
+    fn poll<T>(
         &mut self,
-        event_listener: Pin<&mut EventListener>,
+        event_listener: Pin<&mut EventListener<T>>,
         context: &mut Self::Context,
-    ) -> Poll<()> {
+    ) -> Poll<T> {
         event_listener.poll(context)
     }
 }
@@ -391,13 +391,13 @@ impl<'evl> Strategy<'evl> for Blocking {
     }
 
     #[inline]
-    fn poll(
+    fn poll<T>(
         &mut self,
-        event_listener: Pin<&mut EventListener>,
+        event_listener: Pin<&mut EventListener<T>>,
         _context: &mut Self::Context,
-    ) -> Poll<()> {
-        event_listener.wait();
-        Poll::Ready(())
+    ) -> Poll<T> {
+        let result = event_listener.wait();
+        Poll::Ready(result)
     }
 }
 


### PR DESCRIPTION
Supersedes #40 by adding tags to the event. Similarly to #40, this PR:

- Adds a `T` parameter to `Event` and `EventListener` that is `()` by default.
- **Breaking:** Makes it so `wait()` and friends return `T` or `Option<T>` instead of `()` and `bool`.
- Makes it so polling `EventListener` as a future returns `T` instead of `()`.

Unlike #40, I wanted to use a more sustainable method for notifying the event. Introducing the **Notification** trait. Its API looks like this:

```rust
trait Notification {
    type Tag;
    fn is_additional(&self) -> bool;
    fn count(&self) -> usize;
    fn fence(&self);
    fn next_tag(&mut self) -> T;
}
```

This roughly corresponds to the implicit parameters to the current `event.notify_<is_additional>_<relaxed>(count)` function. `is_additional` sets the `additional` property to `true`, and `relaxed` makes the fence do nothing instead of emitting a `SeqCst` fence. The `next_tag` function emits the tag that gets attached to the notification.

I wanted to give this some power, so I created the **IntoNotification** trait as well.

```rust
trait IntoNotification {
    type Tag;
    type Notify: Notification<Tag = Self::Tag>;
    fn into_notification(self) -> Self::Notify;
    
    fn additional(self) -> Additional<Self::Notify> { .. }
    fn relaxed(self) -> Relaxed<Self::Notify> { .. }
    fn tag<T: Clone>(self, tag: T) -> Tag<Self::Notify, T> { .. }
    fn tag_with<T, F: FnMut() -> T>(self, f: F) -> TagWith<Self::Notify, F> { .. }
}

impl<N: Notification> IntoNotification for N { .. }
impl IntoNotification for usize { .. }
```

This way, if we make `notify()` take an `impl IntoNotification` instead of `usize`, it still works as intended, as the implementation for `usize::into_notification` is non-additional and non-relaxed:

```rust
event.notify(3);
```

You can also use this system to add combinators (`.additional()`, `.relaxed()`), such that:

```rust
// Old code:
event.notify_additional(3);

// New code:
event.notify(3.additional());
```

Then, to add tags to a notification, you would do:

```rust
// Assume tag is a Vec<usize>
event.notify(3.tag(vec![1, 2, 3]));

// Alternate method
event.notify(3.tag_with(|| vec![1, 2, 3]));
```

Discussion questions:

- Should `Notification` and `IntoNotification` be sealed? If it is, it means we can add new methods to it without worrying. If it isn't, it means that users can implement their own notification types. However, that may cause behavior we don't expect.