### PR TITLE
feat: Add a portable-atomic feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - run: rustup target add thumbv7m-none-eabi
       - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps
+      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps --features portable-atomic
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,17 @@ exclude = ["/.*"]
 [features]
 default = ["std"]
 std = ["parking"]
+portable-atomic = ["portable-atomic-util", "portable_atomic_crate"]
 
 [dependencies]
 parking = { version = "2.0.0", optional = true }
+portable-atomic-util = { version = "0.1.1", default-features = false, optional = true, features = ["alloc"] }
+
+[dependencies.portable_atomic_crate]
+package = "portable-atomic"
+version = "1.2.0"
+default-features = false
+optional = true
 
 [dev-dependencies]
 futures-lite = "1.12.0"


### PR DESCRIPTION
Adds a `portable-atomic` feature that uses the `portable-atomic` crate to implement synchronization.