### PR TITLE
Remove the pin-utils dependency

### DIFF
--- a/strategy/Cargo.toml
+++ b/strategy/Cargo.toml
@@ -14,7 +14,6 @@ exclude = ["/.*"]
 [dependencies]
 event-listener = { path = "..", version = "2", default-features = false }
 pin-project-lite = "0.2.9"
-pin-utils = "0.1.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Split out from #50, since we should probably keep `pin-project-lite` but lose the `pin-utils`.