### PR TITLE
Implement loom support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ optional = true
 # The `loom` feature, combined with the `loom` rustflag, enables a reimplementation
 # of `parking` using `loom`. This feature is perma-unstable and should not be used
 # in stable code.
-[target.'cfg(loom)'.dependencies.loom]
-version = "0.6"
-optional = true
+[target.'cfg(loom)'.dependencies]
+concurrent-queue = { version = "2.2.0", default-features = false, features = ["loom"] }
+loom = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 futures-lite = "1.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,13 @@ version = "1.2.0"
 default-features = false
 optional = true
 
+# The `loom` feature, combined with the `loom` rustflag, enables a reimplementation
+# of `parking` using `loom`. This feature is perma-unstable and should not be used
+# in stable code.
+[target.'cfg(loom)'.dependencies.loom]
+version = "0.6"
+optional = true
+
 [dev-dependencies]
 futures-lite = "1.12.0"
 waker-fn = "1"


### PR DESCRIPTION
This PR implements Loom support for `event-listener`.

Blocked on https://github.com/tokio-rs/loom/pull/325, closes #23 