### PR TITLE
Fix a couple of bugs in the no_std implementation

### DIFF
--- a/src/no_std/node.rs
+++ b/src/no_std/node.rs
@@ -127,7 +127,9 @@ impl TaskWaiting {
         // If the entry ID is non-zero, then we are no longer queued.
         if self.status().is_some() {
             // Wake the task.
-            self.task.take().unwrap().wake();
+            if let Some(task) = self.task.take() {
+                task.wake();
+            }
         }
     }
 }

--- a/src/no_std/queue.rs
+++ b/src/no_std/queue.rs
@@ -58,6 +58,7 @@ impl<T> Queue<T> {
 
                 // The head was set by another thread, so we need to try again.
                 tail = self.tail.load(Ordering::Acquire);
+                continue;
             }
 
             unsafe {


### PR DESCRIPTION
- Prevent a panic for when the task has already been taken in the node
- Fix a null pointer dereference in the backup queue