### PR TITLE
Remove tag support from no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,15 +176,18 @@ impl<T> fmt::Debug for Event<T> {
     }
 }
 
-impl<T> Default for Event<T> {
+impl Default for Event {
     #[inline]
     fn default() -> Self {
-        Self::with_tag()
+        Self::new()
     }
 }
 
 impl<T> Event<T> {
     /// Creates a new `Event` with a tag type.
+    ///
+    /// Tagging cannot be implemented efficiently on `no_std`, so this is only available when the
+    /// `std` feature is enabled.
     ///
     /// # Examples
     ///
@@ -193,6 +196,7 @@ impl<T> Event<T> {
     ///
     /// let event = Event::<usize>::with_tag();
     /// ```
+    #[cfg(feature = "std")]
     #[inline]
     pub const fn with_tag() -> Self {
         Self {
@@ -449,7 +453,9 @@ impl Event<()> {
     /// ```
     #[inline]
     pub const fn new() -> Self {
-        Self::with_tag()
+        Self {
+            inner: AtomicPtr::new(ptr::null_mut()),
+        }
     }
 
     /// Notifies a number of active listeners without emitting a `SeqCst` fence.

--- a/src/no_std/queue.rs
+++ b/src/no_std/queue.rs
@@ -130,16 +130,12 @@ impl<T> Drop for Queue<T> {
 #[cfg(test)]
 mod tests {
     use crate::notify::{GenericNotify, Internal, NotificationPrivate};
-    use crate::sys::node::VecProducer;
+    use crate::sys::node::NothingProducer;
 
     use super::*;
 
     fn node_from_num(num: usize) -> Node<()> {
-        Node::Notify(GenericNotify::new(
-            num,
-            true,
-            VecProducer(vec![(); num].into_iter()),
-        ))
+        Node::Notify(GenericNotify::new(num, true, NothingProducer::default()))
     }
 
     fn node_to_num(node: Node<()>) -> usize {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -494,6 +494,9 @@ pub trait IntoNotification: __private::Sealed {
     /// it is possible to optimize a `Mutex` implementation by locking directly on the next listener, without
     /// needing to ever unlock the mutex at all.
     ///
+    /// Tagging functions cannot be implemented efficiently for `no_std`, so this is only available
+    /// when the `std` feature is enabled.
+    ///
     /// # Examples
     ///
     /// ```
@@ -511,6 +514,7 @@ pub trait IntoNotification: __private::Sealed {
     /// assert_eq!(listener1.as_mut().wait(), true);
     /// assert_eq!(listener2.as_mut().wait(), false);
     /// ```
+    #[cfg(feature = "std")]
     fn tag_with<T, F>(self, tag: F) -> TagWith<Self::Notify, F>
     where
         Self: Sized + IntoNotification<Tag = ()>,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -222,6 +222,7 @@ impl<N: fmt::Debug, F> fmt::Debug for TagWith<N, F> {
 
 impl<N, F> TagWith<N, F> {
     /// Create a new `TagFn` with the given tag function and notification.
+    #[cfg(feature = "std")]
     fn new(tag: F, inner: N) -> Self {
         Self { tag, inner }
     }


### PR DESCRIPTION
For tagging to work under no-std mode, the tags would need to be stored in the backup queue. For notifications for std::usize::MAX listeners, this is not possible. Therefore the only strategy left to use that doesn't massively constrain the use of tagging is to remove tags from no_std mode.

Closes #73