### PR TITLE
Add explicit web support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
         run: cargo hack build --all --no-dev-deps
       - run: cargo hack build --all --target thumbv7m-none-eabi --no-default-features --no-dev-deps
       - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps --features portable-atomic
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
+      - run: wasm-pack test --node
+      - run: wasm-pack test --node --no-default-features
+      - run: wasm-pack test --node --no-default-features --features portable-atomic
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ portable-atomic = ["portable-atomic-util", "portable_atomic_crate"]
 
 [dependencies]
 concurrent-queue = { version = "2.2.0", default-features = false }
-parking = { version = "2.0.0", optional = true }
 pin-project-lite = "0.2.12"
 portable-atomic-util = { version = "0.1.2", default-features = false, optional = true, features = ["alloc"] }
+
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+parking = { version = "2.0.0", optional = true }
 
 [dependencies.portable_atomic_crate]
 package = "portable-atomic"
@@ -39,6 +41,9 @@ waker-fn = "1"
 version = "0.4.0"
 default-features = false
 features = ["cargo_bench_support"]
+
+[target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ concurrent-queue = { version = "2.2.0", default-features = false }
 pin-project-lite = "0.2.12"
 portable-atomic-util = { version = "0.1.2", default-features = false, optional = true, features = ["alloc"] }
 
-[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 parking = { version = "2.0.0", optional = true }
 
 [dependencies.portable_atomic_crate]
@@ -42,7 +42,7 @@ version = "0.4.0"
 default-features = false
 features = ["cargo_bench_support"]
 
-[target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [[bench]]

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -2,7 +2,7 @@
 //!
 //! This mutex exposes both blocking and async methods for acquiring a lock.
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+#[cfg(not(target_family = "wasm"))]
 mod example {
     #![allow(dead_code)]
 
@@ -185,7 +185,7 @@ mod example {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+#[cfg(target_family = "wasm")]
 mod example {
     pub(super) fn entry() {
         println!("This example is not supported on wasm yet.");

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -2,182 +2,196 @@
 //!
 //! This mutex exposes both blocking and async methods for acquiring a lock.
 
-#![allow(dead_code)]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+mod example {
+    #![allow(dead_code)]
 
-use std::cell::UnsafeCell;
-use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
-use std::thread;
-use std::time::{Duration, Instant};
+    use std::cell::UnsafeCell;
+    use std::ops::{Deref, DerefMut};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+    use std::time::{Duration, Instant};
 
-use event_listener::Event;
+    use event_listener::Event;
 
-/// A simple mutex.
-struct Mutex<T> {
-    /// Set to `true` when the mutex is locked.
-    locked: AtomicBool,
+    /// A simple mutex.
+    struct Mutex<T> {
+        /// Set to `true` when the mutex is locked.
+        locked: AtomicBool,
 
-    /// Blocked lock operations.
-    lock_ops: Event,
+        /// Blocked lock operations.
+        lock_ops: Event,
 
-    /// The inner protected data.
-    data: UnsafeCell<T>,
+        /// The inner protected data.
+        data: UnsafeCell<T>,
+    }
+
+    unsafe impl<T: Send> Send for Mutex<T> {}
+    unsafe impl<T: Send> Sync for Mutex<T> {}
+
+    impl<T> Mutex<T> {
+        /// Creates a mutex.
+        fn new(t: T) -> Mutex<T> {
+            Mutex {
+                locked: AtomicBool::new(false),
+                lock_ops: Event::new(),
+                data: UnsafeCell::new(t),
+            }
+        }
+
+        /// Attempts to acquire a lock.
+        fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+            if !self.locked.swap(true, Ordering::Acquire) {
+                Some(MutexGuard(self))
+            } else {
+                None
+            }
+        }
+
+        /// Blocks until a lock is acquired.
+        fn lock(&self) -> MutexGuard<'_, T> {
+            let mut listener = None;
+
+            loop {
+                // Attempt grabbing a lock.
+                if let Some(guard) = self.try_lock() {
+                    return guard;
+                }
+
+                // Set up an event listener or wait for a notification.
+                match listener.take() {
+                    None => {
+                        // Start listening and then try locking again.
+                        listener = Some(self.lock_ops.listen());
+                    }
+                    Some(mut l) => {
+                        // Wait until a notification is received.
+                        l.as_mut().wait();
+                    }
+                }
+            }
+        }
+
+        /// Blocks until a lock is acquired or the timeout is reached.
+        fn lock_timeout(&self, timeout: Duration) -> Option<MutexGuard<'_, T>> {
+            let deadline = Instant::now() + timeout;
+            let mut listener = None;
+
+            loop {
+                // Attempt grabbing a lock.
+                if let Some(guard) = self.try_lock() {
+                    return Some(guard);
+                }
+
+                // Set up an event listener or wait for an event.
+                match listener.take() {
+                    None => {
+                        // Start listening and then try locking again.
+                        listener = Some(self.lock_ops.listen());
+                    }
+                    Some(mut l) => {
+                        // Wait until a notification is received.
+                        l.as_mut().wait_deadline(deadline)?;
+                    }
+                }
+            }
+        }
+
+        /// Acquires a lock asynchronously.
+        async fn lock_async(&self) -> MutexGuard<'_, T> {
+            let mut listener = None;
+
+            loop {
+                // Attempt grabbing a lock.
+                if let Some(guard) = self.try_lock() {
+                    return guard;
+                }
+
+                // Set up an event listener or wait for an event.
+                match listener.take() {
+                    None => {
+                        // Start listening and then try locking again.
+                        listener = Some(self.lock_ops.listen());
+                    }
+                    Some(l) => {
+                        // Wait until a notification is received.
+                        l.await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// A guard holding a lock.
+    struct MutexGuard<'a, T>(&'a Mutex<T>);
+
+    unsafe impl<T: Send> Send for MutexGuard<'_, T> {}
+    unsafe impl<T: Sync> Sync for MutexGuard<'_, T> {}
+
+    impl<T> Drop for MutexGuard<'_, T> {
+        fn drop(&mut self) {
+            self.0.locked.store(false, Ordering::Release);
+            self.0.lock_ops.notify(1);
+        }
+    }
+
+    impl<T> Deref for MutexGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            unsafe { &*self.0.data.get() }
+        }
+    }
+
+    impl<T> DerefMut for MutexGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            unsafe { &mut *self.0.data.get() }
+        }
+    }
+
+    pub(super) fn entry() {
+        const N: usize = 10;
+
+        // A shared counter.
+        let counter = Arc::new(Mutex::new(0));
+
+        // A channel that signals when all threads are done.
+        let (tx, rx) = mpsc::channel();
+
+        // Spawn a bunch of threads incrementing the counter.
+        for _ in 0..N {
+            let counter = counter.clone();
+            let tx = tx.clone();
+
+            thread::spawn(move || {
+                let mut counter = counter.lock();
+                *counter += 1;
+
+                // If this is the last increment, signal that we're done.
+                if *counter == N {
+                    tx.send(()).unwrap();
+                }
+            });
+        }
+
+        // Wait until the last thread increments the counter.
+        rx.recv().unwrap();
+
+        // The counter must equal the number of threads.
+        assert_eq!(*counter.lock(), N);
+
+        println!("Done!");
+    }
 }
 
-unsafe impl<T: Send> Send for Mutex<T> {}
-unsafe impl<T: Send> Sync for Mutex<T> {}
-
-impl<T> Mutex<T> {
-    /// Creates a mutex.
-    fn new(t: T) -> Mutex<T> {
-        Mutex {
-            locked: AtomicBool::new(false),
-            lock_ops: Event::new(),
-            data: UnsafeCell::new(t),
-        }
-    }
-
-    /// Attempts to acquire a lock.
-    fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
-        if !self.locked.swap(true, Ordering::Acquire) {
-            Some(MutexGuard(self))
-        } else {
-            None
-        }
-    }
-
-    /// Blocks until a lock is acquired.
-    fn lock(&self) -> MutexGuard<'_, T> {
-        let mut listener = None;
-
-        loop {
-            // Attempt grabbing a lock.
-            if let Some(guard) = self.try_lock() {
-                return guard;
-            }
-
-            // Set up an event listener or wait for a notification.
-            match listener.take() {
-                None => {
-                    // Start listening and then try locking again.
-                    listener = Some(self.lock_ops.listen());
-                }
-                Some(mut l) => {
-                    // Wait until a notification is received.
-                    l.as_mut().wait();
-                }
-            }
-        }
-    }
-
-    /// Blocks until a lock is acquired or the timeout is reached.
-    fn lock_timeout(&self, timeout: Duration) -> Option<MutexGuard<'_, T>> {
-        let deadline = Instant::now() + timeout;
-        let mut listener = None;
-
-        loop {
-            // Attempt grabbing a lock.
-            if let Some(guard) = self.try_lock() {
-                return Some(guard);
-            }
-
-            // Set up an event listener or wait for an event.
-            match listener.take() {
-                None => {
-                    // Start listening and then try locking again.
-                    listener = Some(self.lock_ops.listen());
-                }
-                Some(mut l) => {
-                    // Wait until a notification is received.
-                    l.as_mut().wait_deadline(deadline)?;
-                }
-            }
-        }
-    }
-
-    /// Acquires a lock asynchronously.
-    async fn lock_async(&self) -> MutexGuard<'_, T> {
-        let mut listener = None;
-
-        loop {
-            // Attempt grabbing a lock.
-            if let Some(guard) = self.try_lock() {
-                return guard;
-            }
-
-            // Set up an event listener or wait for an event.
-            match listener.take() {
-                None => {
-                    // Start listening and then try locking again.
-                    listener = Some(self.lock_ops.listen());
-                }
-                Some(l) => {
-                    // Wait until a notification is received.
-                    l.await;
-                }
-            }
-        }
-    }
-}
-
-/// A guard holding a lock.
-struct MutexGuard<'a, T>(&'a Mutex<T>);
-
-unsafe impl<T: Send> Send for MutexGuard<'_, T> {}
-unsafe impl<T: Sync> Sync for MutexGuard<'_, T> {}
-
-impl<T> Drop for MutexGuard<'_, T> {
-    fn drop(&mut self) {
-        self.0.locked.store(false, Ordering::Release);
-        self.0.lock_ops.notify(1);
-    }
-}
-
-impl<T> Deref for MutexGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.0.data.get() }
-    }
-}
-
-impl<T> DerefMut for MutexGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.0.data.get() }
+#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+mod example {
+    pub(super) fn entry() {
+        println!("This example is not supported on wasm yet.");
     }
 }
 
 fn main() {
-    const N: usize = 10;
-
-    // A shared counter.
-    let counter = Arc::new(Mutex::new(0));
-
-    // A channel that signals when all threads are done.
-    let (tx, rx) = mpsc::channel();
-
-    // Spawn a bunch of threads incrementing the counter.
-    for _ in 0..N {
-        let counter = counter.clone();
-        let tx = tx.clone();
-
-        thread::spawn(move || {
-            let mut counter = counter.lock();
-            *counter += 1;
-
-            // If this is the last increment, signal that we're done.
-            if *counter == N {
-                tx.send(()).unwrap();
-            }
-        });
-    }
-
-    // Wait until the last thread increments the counter.
-    rx.recv().unwrap();
-
-    // The counter must equal the number of threads.
-    assert_eq!(*counter.lock(), N);
-
-    println!("Done!");
+    example::entry();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,14 @@ use core::pin::Pin;
 use core::ptr;
 use core::task::{Context, Poll, Waker};
 
-#[cfg(feature = "std")]
-use parking::{Parker, Unparker};
-#[cfg(feature = "std")]
-use std::time::{Duration, Instant};
+#[cfg(all(
+    feature = "std",
+    not(any(target_arch = "wasm32", target_arch = "wasm64")),
+))]
+use {
+    parking::{Parker, Unparker},
+    std::time::{Duration, Instant},
+};
 
 use sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use sync::{Arc, WithMut};
@@ -721,7 +725,10 @@ impl<T> EventListener<T> {
     /// // Receive the notification.
     /// listener.as_mut().wait();
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     pub fn wait(self: Pin<&mut Self>) -> T {
         self.listener().wait_internal(None).unwrap()
     }
@@ -742,7 +749,10 @@ impl<T> EventListener<T> {
     /// // There are no notification so this times out.
     /// assert!(listener.as_mut().wait_timeout(Duration::from_secs(1)).is_none());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     pub fn wait_timeout(self: Pin<&mut Self>, timeout: Duration) -> Option<T> {
         self.listener()
             .wait_internal(Instant::now().checked_add(timeout))
@@ -764,7 +774,10 @@ impl<T> EventListener<T> {
     /// // There are no notification so this times out.
     /// assert!(listener.as_mut().wait_deadline(Instant::now() + Duration::from_secs(1)).is_none());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     pub fn wait_deadline(self: Pin<&mut Self>, deadline: Instant) -> Option<T> {
         self.listener().wait_internal(Some(deadline))
     }
@@ -883,7 +896,10 @@ impl<T, B: Borrow<Inner<T>> + Unpin> Listener<T, B> {
     }
 
     /// Wait until the provided deadline.
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     fn wait_internal(mut self: Pin<&mut Self>, deadline: Option<Instant>) -> Option<T> {
         use std::cell::RefCell;
 
@@ -917,7 +933,10 @@ impl<T, B: Borrow<Inner<T>> + Unpin> Listener<T, B> {
     }
 
     /// Wait until the provided deadline using the specified parker/unparker pair.
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     fn wait_with_parker(
         self: Pin<&mut Self>,
         deadline: Option<Instant>,
@@ -1079,7 +1098,10 @@ enum Task {
     Waker(Waker),
 
     /// An unparker that wakes up a thread.
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     Unparker(Unparker),
 }
 
@@ -1087,7 +1109,10 @@ impl Task {
     fn as_task_ref(&self) -> TaskRef<'_> {
         match self {
             Self::Waker(waker) => TaskRef::Waker(waker),
-            #[cfg(feature = "std")]
+            #[cfg(all(
+                feature = "std",
+                not(any(target_arch = "wasm32", target_arch = "wasm64")),
+            ))]
             Self::Unparker(unparker) => TaskRef::Unparker(unparker),
         }
     }
@@ -1095,7 +1120,10 @@ impl Task {
     fn wake(self) {
         match self {
             Self::Waker(waker) => waker.wake(),
-            #[cfg(feature = "std")]
+            #[cfg(all(
+                feature = "std",
+                not(any(target_arch = "wasm32", target_arch = "wasm64")),
+            ))]
             Self::Unparker(unparker) => {
                 unparker.unpark();
             }
@@ -1116,7 +1144,10 @@ enum TaskRef<'a> {
     Waker(&'a Waker),
 
     /// An unparker that wakes up a thread.
-    #[cfg(feature = "std")]
+    #[cfg(all(
+        feature = "std",
+        not(any(target_arch = "wasm32", target_arch = "wasm64")),
+    ))]
     Unparker(&'a Unparker),
 }
 
@@ -1126,7 +1157,10 @@ impl TaskRef<'_> {
     fn will_wake(self, other: Self) -> bool {
         match (self, other) {
             (Self::Waker(a), Self::Waker(b)) => a.will_wake(b),
-            #[cfg(feature = "std")]
+            #[cfg(all(
+                feature = "std",
+                not(any(target_arch = "wasm32", target_arch = "wasm64")),
+            ))]
             (Self::Unparker(_), Self::Unparker(_)) => {
                 // TODO: Use unreleased will_unpark API.
                 false
@@ -1139,7 +1173,10 @@ impl TaskRef<'_> {
     fn into_task(self) -> Task {
         match self {
             Self::Waker(waker) => Task::Waker(waker.clone()),
-            #[cfg(feature = "std")]
+            #[cfg(all(
+                feature = "std",
+                not(any(target_arch = "wasm32", target_arch = "wasm64")),
+            ))]
             Self::Unparker(unparker) => Task::Unparker(unparker.clone()),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,7 @@ use core::pin::Pin;
 use core::ptr;
 use core::task::{Context, Poll, Waker};
 
-#[cfg(all(
-    feature = "std",
-    not(any(target_arch = "wasm32", target_arch = "wasm64")),
-))]
+#[cfg(all(feature = "std", not(target_family = "wasm"),))]
 use {
     parking::{Parker, Unparker},
     std::time::{Duration, Instant},
@@ -725,10 +722,7 @@ impl<T> EventListener<T> {
     /// // Receive the notification.
     /// listener.as_mut().wait();
     /// ```
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     pub fn wait(self: Pin<&mut Self>) -> T {
         self.listener().wait_internal(None).unwrap()
     }
@@ -749,10 +743,7 @@ impl<T> EventListener<T> {
     /// // There are no notification so this times out.
     /// assert!(listener.as_mut().wait_timeout(Duration::from_secs(1)).is_none());
     /// ```
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     pub fn wait_timeout(self: Pin<&mut Self>, timeout: Duration) -> Option<T> {
         self.listener()
             .wait_internal(Instant::now().checked_add(timeout))
@@ -774,10 +765,7 @@ impl<T> EventListener<T> {
     /// // There are no notification so this times out.
     /// assert!(listener.as_mut().wait_deadline(Instant::now() + Duration::from_secs(1)).is_none());
     /// ```
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     pub fn wait_deadline(self: Pin<&mut Self>, deadline: Instant) -> Option<T> {
         self.listener().wait_internal(Some(deadline))
     }
@@ -896,10 +884,7 @@ impl<T, B: Borrow<Inner<T>> + Unpin> Listener<T, B> {
     }
 
     /// Wait until the provided deadline.
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     fn wait_internal(mut self: Pin<&mut Self>, deadline: Option<Instant>) -> Option<T> {
         use std::cell::RefCell;
 
@@ -933,10 +918,7 @@ impl<T, B: Borrow<Inner<T>> + Unpin> Listener<T, B> {
     }
 
     /// Wait until the provided deadline using the specified parker/unparker pair.
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     fn wait_with_parker(
         self: Pin<&mut Self>,
         deadline: Option<Instant>,
@@ -1098,10 +1080,7 @@ enum Task {
     Waker(Waker),
 
     /// An unparker that wakes up a thread.
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     Unparker(Unparker),
 }
 
@@ -1109,10 +1088,7 @@ impl Task {
     fn as_task_ref(&self) -> TaskRef<'_> {
         match self {
             Self::Waker(waker) => TaskRef::Waker(waker),
-            #[cfg(all(
-                feature = "std",
-                not(any(target_arch = "wasm32", target_arch = "wasm64")),
-            ))]
+            #[cfg(all(feature = "std", not(target_family = "wasm"),))]
             Self::Unparker(unparker) => TaskRef::Unparker(unparker),
         }
     }
@@ -1120,10 +1096,7 @@ impl Task {
     fn wake(self) {
         match self {
             Self::Waker(waker) => waker.wake(),
-            #[cfg(all(
-                feature = "std",
-                not(any(target_arch = "wasm32", target_arch = "wasm64")),
-            ))]
+            #[cfg(all(feature = "std", not(target_family = "wasm"),))]
             Self::Unparker(unparker) => {
                 unparker.unpark();
             }
@@ -1144,10 +1117,7 @@ enum TaskRef<'a> {
     Waker(&'a Waker),
 
     /// An unparker that wakes up a thread.
-    #[cfg(all(
-        feature = "std",
-        not(any(target_arch = "wasm32", target_arch = "wasm64")),
-    ))]
+    #[cfg(all(feature = "std", not(target_family = "wasm"),))]
     Unparker(&'a Unparker),
 }
 
@@ -1157,10 +1127,7 @@ impl TaskRef<'_> {
     fn will_wake(self, other: Self) -> bool {
         match (self, other) {
             (Self::Waker(a), Self::Waker(b)) => a.will_wake(b),
-            #[cfg(all(
-                feature = "std",
-                not(any(target_arch = "wasm32", target_arch = "wasm64")),
-            ))]
+            #[cfg(all(feature = "std", not(target_family = "wasm"),))]
             (Self::Unparker(_), Self::Unparker(_)) => {
                 // TODO: Use unreleased will_unpark API.
                 false
@@ -1173,10 +1140,7 @@ impl TaskRef<'_> {
     fn into_task(self) -> Task {
         match self {
             Self::Waker(waker) => Task::Waker(waker.clone()),
-            #[cfg(all(
-                feature = "std",
-                not(any(target_arch = "wasm32", target_arch = "wasm64")),
-            ))]
+            #[cfg(all(feature = "std", not(target_family = "wasm"),))]
             Self::Unparker(unparker) => Task::Unparker(unparker.clone()),
         }
     }

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -829,11 +829,10 @@ mod tests {
     use super::*;
     use crate::Task;
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[cfg(target_family = "wasm")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
     fn smoke_mutex() {
         let mutex = Mutex::new(0);
 
@@ -851,11 +850,7 @@ mod tests {
         assert_eq!(*guard, 2);
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn smoke_listener_slab() {
         let mut listeners = ListenerSlab::<()>::new();
 
@@ -928,11 +923,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn listener_slab_notify() {
         let mut listeners = ListenerSlab::new();
 
@@ -1017,11 +1008,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn listener_slab_register() {
         let woken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn::waker_fn({
@@ -1128,11 +1115,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn listener_slab_notify_prop() {
         let woken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn::waker_fn({
@@ -1377,11 +1360,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn uncontended_inner() {
         let inner = crate::Inner::new();
 

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -829,7 +829,11 @@ mod tests {
     use super::*;
     use crate::Task;
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn smoke_mutex() {
         let mutex = Mutex::new(0);
 
@@ -847,7 +851,11 @@ mod tests {
         assert_eq!(*guard, 2);
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn smoke_listener_slab() {
         let mut listeners = ListenerSlab::<()>::new();
 
@@ -920,7 +928,11 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn listener_slab_notify() {
         let mut listeners = ListenerSlab::new();
 
@@ -1005,7 +1017,11 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn listener_slab_register() {
         let woken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn::waker_fn({
@@ -1112,7 +1128,11 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn listener_slab_notify_prop() {
         let woken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn::waker_fn({
@@ -1357,7 +1377,11 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn uncontended_inner() {
         let inner = crate::Inner::new();
 

--- a/src/std.rs
+++ b/src/std.rs
@@ -348,7 +348,11 @@ mod tests {
         };
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn insert() {
         let inner = crate::Inner::new();
         make_listeners!(listen1, listen2, listen3);
@@ -369,7 +373,11 @@ mod tests {
         assert_eq!(inner.lock().len, 1);
     }
 
-    #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn drop_non_notified() {
         let inner = crate::Inner::new();
         make_listeners!(listen1, listen2, listen3);

--- a/src/std.rs
+++ b/src/std.rs
@@ -339,6 +339,9 @@ mod tests {
     use super::*;
     use futures_lite::pin;
 
+    #[cfg(target_family = "wasm")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     macro_rules! make_listeners {
         ($($id:ident),*) => {
             $(
@@ -348,11 +351,7 @@ mod tests {
         };
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn insert() {
         let inner = crate::Inner::new();
         make_listeners!(listen1, listen2, listen3);
@@ -373,11 +372,7 @@ mod tests {
         assert_eq!(inner.lock().len, 1);
     }
 
-    #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-    #[cfg_attr(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[test]
     fn drop_non_notified() {
         let inner = crate::Inner::new();
         make_listeners!(listen1, listen2, listen3);

--- a/strategy/tests/easy_wrapper.rs
+++ b/strategy/tests/easy_wrapper.rs
@@ -4,7 +4,11 @@ use std::{marker::PhantomData, pin::Pin, task::Poll};
 
 use event_listener_strategy::{easy_wrapper, EventListenerFuture, Strategy};
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn easy_wrapper_generics() {
     // Easy case.
     struct MyStrategy;

--- a/strategy/tests/easy_wrapper.rs
+++ b/strategy/tests/easy_wrapper.rs
@@ -1,14 +1,12 @@
 //! Testing of the `easy_wrapper!` macro.
 
+use event_listener_strategy::{easy_wrapper, EventListenerFuture, Strategy};
 use std::{marker::PhantomData, pin::Pin, task::Poll};
 
-use event_listener_strategy::{easy_wrapper, EventListenerFuture, Strategy};
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn easy_wrapper_generics() {
     // Easy case.
     struct MyStrategy;

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -12,7 +12,11 @@ fn is_notified(listener: Pin<&mut EventListener>) -> bool {
     listener.poll(&mut Context::from_waker(&waker)).is_ready()
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn notify() {
     let event = Event::new();
 
@@ -32,7 +36,11 @@ fn notify() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn notify_additional() {
     let event = Event::new();
 
@@ -49,7 +57,11 @@ fn notify_additional() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn notify_one() {
     let event = Event::new();
 
@@ -67,7 +79,11 @@ fn notify_one() {
     assert!(is_notified(l2.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn notify_all() {
     let event = Event::new();
 
@@ -82,7 +98,11 @@ fn notify_all() {
     assert!(is_notified(l2.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn drop_notified() {
     let event = Event::new();
 
@@ -96,7 +116,11 @@ fn drop_notified() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn drop_notified2() {
     let event = Event::new();
 
@@ -110,7 +134,11 @@ fn drop_notified2() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn drop_notified_additional() {
     let event = Event::new();
 
@@ -127,7 +155,11 @@ fn drop_notified_additional() {
     assert!(!is_notified(l4.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn drop_non_notified() {
     let event = Event::new();
 
@@ -141,7 +173,11 @@ fn drop_non_notified() {
     assert!(!is_notified(l2.as_mut()));
 }
 
-#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
+#[cfg_attr(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    wasm_bindgen_test::wasm_bindgen_test
+)]
 fn notify_all_fair() {
     let event = Event::new();
     let v = Arc::new(Mutex::new(vec![]));

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -7,16 +7,15 @@ use std::usize;
 use event_listener::{Event, EventListener};
 use waker_fn::waker_fn;
 
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
 fn is_notified(listener: Pin<&mut EventListener>) -> bool {
     let waker = waker_fn(|| ());
     listener.poll(&mut Context::from_waker(&waker)).is_ready()
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn notify() {
     let event = Event::new();
 
@@ -36,11 +35,7 @@ fn notify() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn notify_additional() {
     let event = Event::new();
 
@@ -57,11 +52,7 @@ fn notify_additional() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn notify_one() {
     let event = Event::new();
 
@@ -79,11 +70,7 @@ fn notify_one() {
     assert!(is_notified(l2.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn notify_all() {
     let event = Event::new();
 
@@ -98,11 +85,7 @@ fn notify_all() {
     assert!(is_notified(l2.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn drop_notified() {
     let event = Event::new();
 
@@ -116,11 +99,7 @@ fn drop_notified() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn drop_notified2() {
     let event = Event::new();
 
@@ -134,11 +113,7 @@ fn drop_notified2() {
     assert!(!is_notified(l3.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn drop_notified_additional() {
     let event = Event::new();
 
@@ -155,11 +130,7 @@ fn drop_notified_additional() {
     assert!(!is_notified(l4.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn drop_non_notified() {
     let event = Event::new();
 
@@ -173,11 +144,7 @@ fn drop_non_notified() {
     assert!(!is_notified(l2.as_mut()));
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), test)]
-#[cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    wasm_bindgen_test::wasm_bindgen_test
-)]
+#[test]
 fn notify_all_fair() {
     let event = Event::new();
     let v = Arc::new(Mutex::new(vec![]));


### PR DESCRIPTION
This commit adds WASM compilation support to this crate. The main thing is that the wait() family of APIs are removed in WASM mode, as blocking is not allowed in WASM.

In addition, tests are added to CI to support WASM.