### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "event-listener"
 # - Create "v3.x.y" git tag
 version = "3.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.59"
 description = "Notify async tasks or threads"
 license = "Apache-2.0 OR MIT"
@@ -51,4 +51,3 @@ harness = false
 
 [lib]
 bench = false
-

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -558,7 +558,6 @@ macro_rules! impl_for_numeric_types {
                     panic!("negative notification count");
                 }
 
-                use core::convert::TryInto;
                 Notify::new(self.try_into().expect("overflow"))
             }
         }


### PR DESCRIPTION
Our MSRV (1.59) is higher than 1.56 that Rust 2021 was stabilized.