### PR TITLE
Document that EventListeners must be listen'd on

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,10 +658,10 @@ pin_project_lite::pin_project! {
     /// another active listener. Whether one *additional* listener will be notified depends on what
     /// kind of notification was delivered.
     ///
-    /// The listener is not registered into the linked list inside of the [`Event`] by default. It
-    /// needs to be pinned first before being inserted using the `listen()` method. After the
-    /// listener has begun `listen`ing, the user can `await` it like a future or call `wait()`
-    /// to block the current thread until it is notified.
+    /// The listener is not registered into the linked list inside of the [`Event`] by default if
+    /// it is created via the `new()` method. It needs to be pinned first before being inserted
+    /// using the `listen()` method. After the listener has begun `listen`ing, the user can
+    /// `await` it like a future or call `wait()` to block the current thread until it is notified.
     ///
     /// ## Examples
     ///
@@ -675,10 +675,11 @@ pin_project_lite::pin_project! {
     /// let flag = Arc::new(AtomicBool::new(false));
     ///
     /// // Create an event to wait on.
-    /// let event = Event::new();
+    /// let event = Arc::new(Event::new());
     ///
     /// thread::spawn({
     ///     let flag = flag.clone();
+    ///     let event = event.clone();
     ///     move || {
     ///         thread::sleep(Duration::from_secs(2));
     ///         flag.store(true, Ordering::SeqCst);

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -9,6 +9,8 @@ pub(crate) use __private::Internal;
 /// The type of notification to use with an [`Event`].
 ///
 /// This is hidden and sealed to prevent changes to this trait from being breaking.
+///
+/// [`Event`]: crate::Event
 #[doc(hidden)]
 pub trait NotificationPrivate {
     /// The tag data associated with a notification.
@@ -52,6 +54,8 @@ pub trait NotificationPrivate {
 ///
 /// notify(&Event::new(), 1.additional());
 /// ```
+///
+/// [`Event`]: crate::Event
 pub trait Notification: NotificationPrivate {}
 impl<N: NotificationPrivate + ?Sized> Notification for N {}
 


### PR DESCRIPTION
In retrospect it is sometimes unclear in the documentation that the new event listener needs to be pinned and inserted into the list before it can receive events. This PR adds documentation that should clarify this issue.

Closes #89
cc @zeenix 