### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.0.1
+
+- Emphasize that `listen()` must be called on `EventListener` in documentation. (#90)
+- Write useful output in `fmt::Debug` implementations. (#86)
+
 # Version 3.0.0
 
 - Use the `parking` crate instead of threading APIs (#27)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.59"


### PR DESCRIPTION
- Emphasize that `listen()` must be called on `EventListener` in documentation. (#90)
- Write useful output in `fmt::Debug` implementations. (#86)
