### PR TITLE
v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 4.0.0
+
+- **Breaking:** Fix a footgun in the `EventListener` type. `EventListener::new()`
+  now no longer takes an `&Event` as an argument, and `EventListener::listen()`
+  takes the  `&Event` as an argument. Hopefully this should prevent `.await`ing
+  on a listener without making sure it's listening first. (#94)
+
 # Version 3.1.0
 
 - Implement `UnwindSafe` and `RefUnwindSafe` for `EventListener`. This was unintentionally removed in version 3 (#96).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v3.x.y" git tag
-version = "3.1.0"
+# - Create "v4.x.y" git tag
+version = "4.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.59"


### PR DESCRIPTION
- **Breaking:** Fix a footgun in the `EventListener` type. `EventListener::new()` now no longer takes an `&Event` as an argument, and `EventListener::listen()` takes the  `&Event` as an argument. Hopefully this should prevent `.await`ing on a listener without making sure it's listening first. (#94)
