### PR TITLE
Remove listener if one already exists

### DIFF
--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -189,3 +189,16 @@ fn notify_all_fair() {
         .poll(&mut Context::from_waker(&waker3))
         .is_ready());
 }
+
+#[test]
+fn more_than_one_event() {
+    let event = Event::new();
+    let event2 = Event::new();
+
+    let mut listener = Box::pin(EventListener::<()>::new());
+    listener.as_mut().listen(&event);
+    listener.as_mut().listen(&event2);
+
+    drop(listener);
+    event.notify(1);
+}


### PR DESCRIPTION
This commit makes it so EventListener::listen() does not overwrite
existing listeners if they already exist. If the listener is already
registered in an event listener list, it removes the listener from that
list before registering the new listener. This soundness bug was missed
during #94.

This is a patch-compatible fix for #100. We may also want an API-level
fix for #100 as well. This is up for further discussion.
