### PR TITLE
v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 4.0.1
+
+- Fix a use-after-move error after an `EventListener` is assigned to listen to
+  another `Event`. (#101)
+
 # Version 4.0.0
 
 - **Breaking:** Fix a footgun in the `EventListener` type. `EventListener::new()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v4.x.y" git tag
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.61"


### PR DESCRIPTION
- Fix a use-after-move error after an `EventListener` is assigned to listen to another `Event`. (#101)
