### PR TITLE
v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 4.0.2
+
+- Avoid spinning in `wait_deadline`. (#107)
+
 # Version 4.0.1
 
 - Fix a use-after-move error after an `EventListener` is assigned to listen to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v4.x.y" git tag
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.61"


### PR DESCRIPTION
- Avoid spinning in `wait_deadline`. (#107)
