### PR TITLE
v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 5.0.0
+
+- **Breaking:** Rework the API to afford better usage. (#105)
+  - The heap-based API of the v2.x line is back.
+  - However, there is a stack-based API as an alternative.
+- Add a way to get the total number of listeners. (#114)
+
 # Version 4.0.3
 
 - Relax MSRV to 1.60. (#110)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v4.x.y" git tag
-version = "4.0.3"
+# - Create "v5.x.y" git tag
+version = "5.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- **Breaking:** Rework the API to afford better usage. (#105)
  - The heap-based API of the v2.x line is back.
  - However, there is a stack-based API as an alternative.
- Add a way to get the total number of listeners. (#114)
