### PR TITLE
Mark StackSlot as Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
 
 #[cfg_attr(feature = "std", path = "std.rs")]
 #[cfg_attr(not(feature = "std"), path = "no_std.rs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ mod sys;
 
 mod notify;
 
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 use core::borrow::Borrow;
@@ -1365,6 +1366,9 @@ fn __test_send_and_sync() {
     fn _assert_sync<T: Sync>() {}
 
     _assert_send::<crate::__private::StackSlot<'_, ()>>();
+    _assert_sync::<crate::__private::StackSlot<'_, ()>>();
+    _assert_send::<crate::__private::StackListener<'_, '_, ()>>();
+    _assert_sync::<crate::__private::StackListener<'_, '_, ()>>();
     _assert_send::<Event<()>>();
     _assert_sync::<Event<()>>();
     _assert_send::<EventListener<()>>();
@@ -1410,6 +1414,7 @@ pub mod __private {
     impl<T> core::panic::UnwindSafe for StackSlot<'_, T> {}
     impl<T> core::panic::RefUnwindSafe for StackSlot<'_, T> {}
     unsafe impl<T> Send for StackSlot<'_, T> {}
+    unsafe impl<T> Sync for StackSlot<'_, T> {}
 
     impl<'ev, T> StackSlot<'ev, T> {
         /// Create a new `StackSlot` on the stack.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 #[cfg_attr(feature = "std", path = "std.rs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 #[cfg_attr(feature = "std", path = "std.rs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!
 //! [`portable-atomic`]: https://crates.io/crates/portable-atomic
 
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -832,7 +832,6 @@ unsafe impl<T: Send> Sync for Mutex<T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Task;
 
     #[cfg(target_family = "wasm")]
     use wasm_bindgen_test::wasm_bindgen_test as test;


### PR DESCRIPTION
Since it has no interior mutability it should be safe to share between
threads.
