### PR TITLE
feat: Add a loom implementation for event-listener

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,14 @@ jobs:
       - uses: rustsec/audit-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  loom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Loom tests
+        run: RUSTFLAGS="--cfg=loom" cargo test --release --test loom --features loom  
+        
+    

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,18 @@ exclude = ["/.*"]
 default = ["std"]
 std = ["concurrent-queue/std", "parking"]
 portable-atomic = ["portable-atomic-util", "portable_atomic_crate"]
+loom = ["concurrent-queue/loom", "parking?/loom", "dep:loom"]
 
 [dependencies]
-concurrent-queue = { version = "2.2.0", default-features = false }
+concurrent-queue = { version = "2.4.0", default-features = false }
 pin-project-lite = "0.2.12"
 portable-atomic-util = { version = "0.1.4", default-features = false, optional = true, features = ["alloc"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 parking = { version = "2.0.0", optional = true }
+
+[target.'cfg(loom)'.dependencies]
+loom = { version = "0.7", optional = true }
 
 [dependencies.portable_atomic_crate]
 package = "portable-atomic"

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,212 @@
+#![cfg(loom)]
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::Context;
+use std::usize;
+
+use event_listener::{Event, EventListener};
+use waker_fn::waker_fn;
+
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+fn is_notified(listener: &mut EventListener) -> bool {
+    let waker = waker_fn(|| ());
+    Pin::new(listener)
+        .poll(&mut Context::from_waker(&waker))
+        .is_ready()
+}
+
+#[test]
+fn notify() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+
+        assert!(!is_notified(&mut l1));
+        assert!(!is_notified(&mut l2));
+        assert!(!is_notified(&mut l3));
+
+        assert_eq!(event.notify(2), 2);
+        assert_eq!(event.notify(1), 0);
+
+        assert!(is_notified(&mut l1));
+        assert!(is_notified(&mut l2));
+        assert!(!is_notified(&mut l3));
+    });
+}
+
+#[test]
+fn notify_additional() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+
+        assert_eq!(event.notify_additional(1), 1);
+        assert_eq!(event.notify(1), 0);
+        assert_eq!(event.notify_additional(1), 1);
+
+        assert!(is_notified(&mut l1));
+        assert!(is_notified(&mut l2));
+        assert!(!is_notified(&mut l3));
+    })
+}
+
+#[test]
+fn notify_one() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+
+        assert!(!is_notified(&mut l1));
+        assert!(!is_notified(&mut l2));
+
+        assert_eq!(event.notify(1), 1);
+        assert!(is_notified(&mut l1));
+        assert!(!is_notified(&mut l2));
+
+        assert_eq!(event.notify(1), 1);
+        assert!(is_notified(&mut l2));
+    });
+}
+
+#[test]
+fn notify_all() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+
+        assert!(!is_notified(&mut l1));
+        assert!(!is_notified(&mut l2));
+
+        assert_eq!(event.notify(usize::MAX), 2);
+        assert!(is_notified(&mut l1));
+        assert!(is_notified(&mut l2));
+    });
+}
+
+#[test]
+fn drop_notified() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+
+        assert_eq!(event.notify(1), 1);
+        drop(l1);
+        assert!(is_notified(&mut l2));
+        assert!(!is_notified(&mut l3));
+    });
+}
+
+#[test]
+fn drop_notified2() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+
+        assert_eq!(event.notify(2), 2);
+        drop(l1);
+        assert!(is_notified(&mut l2));
+        assert!(!is_notified(&mut l3));
+    });
+}
+
+#[test]
+fn drop_notified_additional() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+        let mut l4 = event.listen();
+
+        assert_eq!(event.notify_additional(1), 1);
+        assert_eq!(event.notify(2), 1);
+        drop(l1);
+        assert!(is_notified(&mut l2));
+        assert!(is_notified(&mut l3));
+        assert!(!is_notified(&mut l4));
+    });
+}
+
+#[test]
+fn drop_non_notified() {
+    loom::model(|| {
+        let event = Event::new();
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+        let l3 = event.listen();
+
+        assert_eq!(event.notify(1), 1);
+        drop(l3);
+        assert!(is_notified(&mut l1));
+        assert!(!is_notified(&mut l2));
+    })
+}
+
+#[test]
+fn notify_all_fair() {
+    loom::model(|| {
+        let event = Event::new();
+        let v = Arc::new(Mutex::new(vec![]));
+
+        let mut l1 = event.listen();
+        let mut l2 = event.listen();
+        let mut l3 = event.listen();
+
+        let waker1 = {
+            let v = v.clone();
+            waker_fn(move || v.lock().unwrap().push(1))
+        };
+        let waker2 = {
+            let v = v.clone();
+            waker_fn(move || v.lock().unwrap().push(2))
+        };
+        let waker3 = {
+            let v = v.clone();
+            waker_fn(move || v.lock().unwrap().push(3))
+        };
+
+        assert!(Pin::new(&mut l1)
+            .poll(&mut Context::from_waker(&waker1))
+            .is_pending());
+        assert!(Pin::new(&mut l2)
+            .poll(&mut Context::from_waker(&waker2))
+            .is_pending());
+        assert!(Pin::new(&mut l3)
+            .poll(&mut Context::from_waker(&waker3))
+            .is_pending());
+
+        assert_eq!(event.notify(usize::MAX), 3);
+        assert_eq!(&*v.lock().unwrap(), &[1, 2, 3]);
+
+        assert!(Pin::new(&mut l1)
+            .poll(&mut Context::from_waker(&waker1))
+            .is_ready());
+        assert!(Pin::new(&mut l2)
+            .poll(&mut Context::from_waker(&waker2))
+            .is_ready());
+        assert!(Pin::new(&mut l3)
+            .poll(&mut Context::from_waker(&waker3))
+            .is_ready());
+    })
+}


### PR DESCRIPTION
The loom tests aren't particularly useful yet, but the crate compiles and runs under loom now.

Note: This crate does not currently compile under loom without std because concurrent-queue does not compile with that combination (can't find spin_loop).

closes #23 