### PR TITLE
v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 5.3.0
+
+- Add a `loom` implementation. This feature is unstable and is not semver-supported. (#126)
+- Make the panic message for polling the `EventListener` after it has completed more clear. (#125)
+
 # Version 5.2.0
 
 - Make `StackSlot` `Sync`. (#121)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v5.x.y" git tag
-version = "5.2.0"
+version = "5.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Add a `loom` implementation. This feature is unstable and is not semver-supported. (#126)
- Make the panic message for polling the `EventListener` after it has completed more clear. (#125)

