### PR TITLE
Make this crate work on embedded targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ exclude = ["/.*"]
 [features]
 default = ["std"]
 std = ["concurrent-queue/std", "parking"]
-portable-atomic = ["portable-atomic-util", "portable_atomic_crate"]
+portable-atomic = [
+  "portable-atomic-util",
+  "portable_atomic_crate",
+  "concurrent-queue/portable-atomic",
+]
 loom = ["concurrent-queue/loom", "parking?/loom", "dep:loom"]
 
 [lints.rust]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,13 @@
 //!
 //! # Features
 //!
+//! - The `std` feature (enabled by default) enables the use of the Rust standard library. Disable it for `no_std`
+//! support
+//!
 //! - The `portable-atomic` feature enables the use of the [`portable-atomic`] crate to provide
 //!   atomic operations on platforms that don't support them.
 //!
 //! [`portable-atomic`]: https://crates.io/crates/portable-atomic
-//!
-//! - The `std` feature enables the use of the Rust standard library. Disable it for `no_std`
-//! support
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::multiple_bound_locations)] // This is a WONTFIX issue with pin-project-lite

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@
 //!   atomic operations on platforms that don't support them.
 //!
 //! [`portable-atomic`]: https://crates.io/crates/portable-atomic
+//!
+//! - The `std` feature enables the use of the Rust standard library. Disable it for `no_std`
+//! support
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::multiple_bound_locations)] // This is a WONTFIX issue with pin-project-lite


### PR DESCRIPTION
- Document `std` feature
- Set `concurrent-queue/portable-atomic` feature correctly