### PR TITLE
Fix new nightly Clippy warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+//! Emits the necessary "checked" compile time flag warning for "loom".
+//!
+//! Without this, the compiler complains about the unspecified "loom" flag.
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(loom)");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //! [`portable-atomic`]: https://crates.io/crates/portable-atomic
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::multiple_bound_locations)] // This is a WONTFIX issue with pin-project-lite
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
@@ -131,7 +132,7 @@ struct Inner<T> {
 impl<T> Inner<T> {
     fn new() -> Self {
         Self {
-            notified: AtomicUsize::new(core::usize::MAX),
+            notified: AtomicUsize::new(usize::MAX),
             list: sys::List::new(),
         }
     }
@@ -438,7 +439,7 @@ impl<T> Event<T> {
 
         if let Some(inner) = self.try_inner() {
             let limit = if notify.is_additional(Internal::new()) {
-                core::usize::MAX
+                usize::MAX
             } else {
                 notify.count(Internal::new())
             };

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -307,7 +307,7 @@ impl<T> Drop for ListGuard<'_, T> {
             let notified = if list.notified < list.len {
                 list.notified
             } else {
-                core::usize::MAX
+                usize::MAX
             };
 
             self.inner.notified.store(notified, Ordering::Release);

--- a/src/std.rs
+++ b/src/std.rs
@@ -306,7 +306,7 @@ impl<T> Drop for ListLock<'_, '_, T> {
         let notified = if list.notified < list.len {
             list.notified
         } else {
-            core::usize::MAX
+            usize::MAX
         };
 
         self.inner.notified.store(notified, Ordering::Release);

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::Context;
-use std::usize;
 
 use event_listener::{Event, EventListener};
 use waker_fn::waker_fn;

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::Context;
-use std::usize;
 
 use event_listener::{Event, EventListener};
 use waker_fn::waker_fn;


### PR DESCRIPTION
- Suppress warning from the cfg(loom) directive by having it emit
  "rustc-check-cfg" in build.rs
- Remove usage of legacy "std::usize" module.
- Ignore "clippy::multiple_bound_locations". We use multiple bounds as a
  workaround for an issue in pin-project-lite where only one bound can be
  assigned per location. The phrasing of pin-project-lite's README implies that
  this issue is WONTFIX. To quote:

> This library does not tackle as expansive of a range of use cases as
> pin-project does. If your use case is not already covered, please use
> pin-project.
