### PR TITLE
Disable early-out notify optimizations

### DIFF
--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -45,11 +45,6 @@ impl<T> crate::Inner<T> {
         drop(self.try_lock());
     }
 
-    pub(crate) fn needs_notification(&self, _limit: usize) -> bool {
-        // TODO: Figure out a stable way to do this optimization.
-        true
-    }
-
     /// Add a new listener to the list.
     ///
     /// Does nothing if the list is already registered.

--- a/src/std.rs
+++ b/src/std.rs
@@ -64,11 +64,6 @@ impl<T> crate::Inner<T> {
         }
     }
 
-    /// Whether or not this number of listeners would lead to a notification.
-    pub(crate) fn needs_notification(&self, limit: usize) -> bool {
-        self.notified.load(Ordering::Acquire) < limit
-    }
-
     /// Add a new listener to the list.
     pub(crate) fn insert(&self, mut listener: Pin<&mut Option<Listener<T>>>) {
         let mut inner = self.lock();


### PR DESCRIPTION
The notify() function contains two optimizations:

- If the `inner` field is not yet initialized (i.e. no listeners have been
  created yet), it returns `0` from the function early.
- If the atomic `notified` field indicates that the current notification would
  do nothing, it returns `0` early as well.

`loom` testing has exposed race conditions in these optimizations that can cause
notifications to be missed, leading to deadlocks. This commit removes these
optimizations in the hope of preventing these deadlocks. Ideally we can restore
them in the future.

Closes #138
cc #130 and #133
