### PR TITLE
v5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 5.3.1
+
+- Disable some optimizations that, in rare conditions, can cause race conditions
+  causing notifications to be dropped. (#139)
+- Ensure the portable-atomic feature is set properly. (#134)
+- Update `portable-atomic-util` to v0.2.0. (#132)
+- Document the std feature. (#134)
+
 # Version 5.3.0
 
 - Add a `loom` implementation. This feature is unstable and is not semver-supported. (#126)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v5.x.y" git tag
-version = "5.3.0"
-authors = ["Stjepan Glavina <stjepang@gmail.com>"]
+version = "5.3.1"
+authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.60"
 description = "Notify async tasks or threads"


### PR DESCRIPTION
- Disable some optimizations that, in rare conditions, can cause race conditions
  causing notifications to be dropped. (#139)
- Ensure the portable-atomic feature is set properly. (#134)
- Update `portable-atomic-util` to v0.2.0. (#132)
- Document the std feature. (#134)