### PR TITLE
v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 5.4.0
+
+- Add a `no_std` implementation based on the `critical-section` crate, enabled
+  via the feature of the same name. (#148)
+
 # Version 5.3.1
 
 - Disable some optimizations that, in rare conditions, can cause race conditions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v5.x.y" git tag
-version = "5.3.1"
+version = "5.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Add a `no_std` implementation based on the `critical-section` crate, enabled via the feature of the same name. (#148)
