### PR TITLE
ci: Use reusable workflows for fmt and security_audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -104,14 +114,6 @@ jobs:
         run: rustup update stable
       - run: cargo clippy --all --all-features --all-targets
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -147,22 +149,6 @@ jobs:
            cargo miri test --manifest-path=event-listener-strategy/Cargo.toml
            cargo miri test --manifest-path=async-lock/Cargo.toml
 
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   loom:
     runs-on: ubuntu-latest
     steps:
@@ -170,6 +156,4 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: Loom tests
-        run: RUSTFLAGS="--cfg=loom" cargo test --release --test loom --features loom  
-        
-    
+        run: RUSTFLAGS="--cfg=loom" cargo test --release --test loom --features loom


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
