### PR TITLE
Minor amendment to `wait_timeout` docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,7 +765,7 @@ pub trait Listener<T = ()>: Future<Output = T> + __sealed::Sealed {
 
     /// Blocks until a notification is received or a timeout is reached.
     ///
-    /// Returns `true` if a notification was received.
+    /// Returns `Some` if a notification was received.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This trait method returns `Option<T>` rather than `bool`.