### PR TITLE
v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 5.4.1
+
+- Fix a copy-paste error in `wait_timeout` docs (#152)
+
 # Version 5.4.0
 
 - Add a `no_std` implementation based on the `critical-section` crate, enabled

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "event-listener"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v5.x.y" git tag
-version = "5.4.0"
+version = "5.4.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Fix a copy-paste error in `wait_timeout` docs (#152)
