### PR TITLE
Fix unbounded Send/Sync implementations on StackSlot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1496,8 +1496,8 @@ pub mod __private {
 
     impl<T> core::panic::UnwindSafe for StackSlot<'_, T> {}
     impl<T> core::panic::RefUnwindSafe for StackSlot<'_, T> {}
-    unsafe impl<T> Send for StackSlot<'_, T> {}
-    unsafe impl<T> Sync for StackSlot<'_, T> {}
+    unsafe impl<T: Send> Send for StackSlot<'_, T> {}
+    unsafe impl<T: Send> Sync for StackSlot<'_, T> {}
 
     impl<'ev, T> StackSlot<'ev, T> {
         /// Create a new `StackSlot` on the stack.


### PR DESCRIPTION
If `T` is `!Send` and an `Event<T>` is created via `Event::<T>::with_tag()` the `listener!` macro can obtain a pinned mutable reference to a `StackSlot<T>`. 
After notifying  the event with `T`  the  pinned mutable reference to `StackSlot` can be moved to another thread where `.wait()` returns the `!Send` tag.

## Reproduction:
```
#[test]
fn unsafe_sync_data_race() {
    let cell = Cell::new(0);
    let event = Event::<&Cell<i32>>::with_tag();
    listener!(event => l);
    event.notify(1usize.tag(&cell));
    let observed = thread::scope(|s| {
        s.spawn(move || l.wait().set(1)); // write from thread B
        cell.get() // read from thread A — data race
    });
}
```

The example program above reports a race with the [RustMC stateless model checker](https://github.com/Ollie-Pearce/rustmc) and the Miri undefined behaviour detection tool.

## Fix: 
Add `T: Send` bounds for `StackSlot` `Sync`/`Send` impls

```
unsafe impl<T: Send> Send for StackSlot<'_, T> {}
unsafe impl<T: Send> Sync for StackSlot<'_, T> {}
```