### PR TITLE
feat: Re-enable `no_std` support for tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,9 +224,6 @@ impl Default for Event {
 impl<T> Event<T> {
     /// Creates a new `Event` with a tag type.
     ///
-    /// Tagging cannot be implemented efficiently on `no_std`, so this is only available when the
-    /// `std` feature is enabled.
-    ///
     /// # Examples
     ///
     /// ```
@@ -234,14 +231,14 @@ impl<T> Event<T> {
     ///
     /// let event = Event::<usize>::with_tag();
     /// ```
-    #[cfg(all(feature = "std", not(loom)))]
+    #[cfg(not(loom))]
     #[inline]
     pub const fn with_tag() -> Self {
         Self {
             inner: AtomicPtr::new(ptr::null_mut()),
         }
     }
-    #[cfg(all(feature = "std", loom))]
+    #[cfg(loom)]
     #[inline]
     pub fn with_tag() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,11 @@ impl Default for Event {
 impl<T> Event<T> {
     /// Creates a new `Event` with a tag type.
     ///
+    /// Tags are short messages passed to listeners when they are notified. They are [cloned]
+    /// or [generated] and sent to each listener under an internal lock, so the corresponding
+    /// operation should be small and cheap. If you don't need a tag, use [`Event::new()`]
+    /// instead.
+    ///
     /// # Examples
     ///
     /// ```
@@ -231,6 +236,9 @@ impl<T> Event<T> {
     ///
     /// let event = Event::<usize>::with_tag();
     /// ```
+    ///
+    /// [cloned]: IntoNotification::tag
+    /// [generated]: IntoNotification::tag_with
     #[cfg(not(loom))]
     #[inline]
     pub const fn with_tag() -> Self {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -467,8 +467,9 @@ pub trait IntoNotification: __private::Sealed {
     /// it is possible to optimize a `Mutex` implementation by locking directly on the next listener, without
     /// needing to ever unlock the mutex at all.
     ///
-    /// The tag provided is cloned to provide the tag for all listeners. In cases where this is not flexible
-    /// enough, use [`IntoNotification::tag_with()`] instead.
+    /// The tag provided is cloned to provide the tag for all listeners under an internal lock, so they should be
+    /// small and cheap to clone. In cases where this is not flexible enough, use
+    /// [`IntoNotification::tag_with()`] instead.
     ///
     /// # Examples
     ///
@@ -502,6 +503,10 @@ pub trait IntoNotification: __private::Sealed {
     /// it is possible to optimize a `Mutex` implementation by locking directly on the next listener, without
     /// needing to ever unlock the mutex at all.
     ///
+    /// The provided function is called under an internal lock to provide the tag for each listener, so it should be
+    /// lightweight and cheap to call. Specifically, calling [`notify`] inside the function will deadlock the
+    /// current execution context.
+    ///
     /// # Examples
     ///
     /// ```
@@ -521,6 +526,8 @@ pub trait IntoNotification: __private::Sealed {
     /// assert_eq!(listener2.wait(), false);
     /// # }
     /// ```
+    ///
+    /// [`notify`]: crate::Event::notify
     fn tag_with<T, F>(self, tag: F) -> TagWith<Self::Notify, F>
     where
         Self: Sized + IntoNotification<Tag = ()>,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,8 +1,8 @@
 //! The `Notification` trait for specifying notification.
 
-use crate::sync::atomic::{self, Ordering};
-#[cfg(feature = "std")]
 use core::fmt;
+
+use crate::sync::atomic::{self, Ordering};
 
 pub(crate) use __private::Internal;
 
@@ -160,7 +160,6 @@ where
 }
 
 /// Use a tag to notify listeners.
-#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 #[doc(hidden)]
 pub struct Tag<N: ?Sized, T> {
@@ -168,7 +167,6 @@ pub struct Tag<N: ?Sized, T> {
     inner: N,
 }
 
-#[cfg(feature = "std")]
 impl<N: ?Sized, T> Tag<N, T> {
     /// Create a new `Tag` with the given tag and notification.
     fn new(tag: T, inner: N) -> Self
@@ -179,7 +177,6 @@ impl<N: ?Sized, T> Tag<N, T> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<N, T> NotificationPrivate for Tag<N, T>
 where
     N: Notification + ?Sized,
@@ -205,14 +202,12 @@ where
 }
 
 /// Use a function to generate a tag to notify listeners.
-#[cfg(feature = "std")]
 #[doc(hidden)]
 pub struct TagWith<N: ?Sized, F> {
     tag: F,
     inner: N,
 }
 
-#[cfg(feature = "std")]
 impl<N: fmt::Debug, F> fmt::Debug for TagWith<N, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         struct Ellipses;
@@ -230,7 +225,6 @@ impl<N: fmt::Debug, F> fmt::Debug for TagWith<N, F> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<N, F> TagWith<N, F> {
     /// Create a new `TagFn` with the given tag function and notification.
     fn new(tag: F, inner: N) -> Self {
@@ -238,7 +232,6 @@ impl<N, F> TagWith<N, F> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<N, F, T> NotificationPrivate for TagWith<N, F>
 where
     N: Notification + ?Sized,
@@ -475,10 +468,7 @@ pub trait IntoNotification: __private::Sealed {
     /// needing to ever unlock the mutex at all.
     ///
     /// The tag provided is cloned to provide the tag for all listeners. In cases where this is not flexible
-    /// enough, use [`IntoNotification::with_tag()`] instead.
-    ///
-    /// Tagging functions cannot be implemented efficiently for `no_std`, so this is only available
-    /// when the `std` feature is enabled.
+    /// enough, use [`IntoNotification::tag_with()`] instead.
     ///
     /// # Examples
     ///
@@ -499,7 +489,6 @@ pub trait IntoNotification: __private::Sealed {
     /// assert_eq!(listener2.wait(), false);
     /// # }
     /// ```
-    #[cfg(feature = "std")]
     fn tag<T: Clone>(self, tag: T) -> Tag<Self::Notify, T>
     where
         Self: Sized + IntoNotification<Tag = ()>,
@@ -512,9 +501,6 @@ pub trait IntoNotification: __private::Sealed {
     /// In many cases, it is desired to send additional information to the listener of the [`Event`]. For instance,
     /// it is possible to optimize a `Mutex` implementation by locking directly on the next listener, without
     /// needing to ever unlock the mutex at all.
-    ///
-    /// Tagging functions cannot be implemented efficiently for `no_std`, so this is only available
-    /// when the `std` feature is enabled.
     ///
     /// # Examples
     ///
@@ -535,7 +521,6 @@ pub trait IntoNotification: __private::Sealed {
     /// assert_eq!(listener2.wait(), false);
     /// # }
     /// ```
-    #[cfg(feature = "std")]
     fn tag_with<T, F>(self, tag: F) -> TagWith<Self::Notify, F>
     where
         Self: Sized + IntoNotification<Tag = ()>,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -485,7 +485,8 @@ pub trait IntoNotification: __private::Sealed {
     /// event.notify(1.additional().tag(true));
     /// event.notify(1.additional().tag(false));
     ///
-    /// # #[cfg(not(target_family = "wasm"))] { // Listener::wait is unavailable on WASM
+    /// # #[cfg(all(feature = "std", not(target_family = "wasm")))] {
+    /// # // Listener::wait is unavailable on WASM
     /// assert_eq!(listener1.wait(), true);
     /// assert_eq!(listener2.wait(), false);
     /// # }
@@ -521,7 +522,8 @@ pub trait IntoNotification: __private::Sealed {
     /// event.notify(1.additional().tag_with(|| true));
     /// event.notify(1.additional().tag_with(|| false));
     ///
-    /// # #[cfg(not(target_family = "wasm"))] { // Listener::wait is unavailable on WASM
+    /// # #[cfg(all(feature = "std", not(target_family = "wasm")))] {
+    /// # // Listener::wait is unavailable on WASM
     /// assert_eq!(listener1.wait(), true);
     /// assert_eq!(listener2.wait(), false);
     /// # }


### PR DESCRIPTION
Since the slab queue implementation has been removed and `no_std` support without critical sections is about to be deprecated (assuming no plan for custom `lock_api`-based support), both `std` and `critical-section` backends can enable efficient locking mechanisms for listener lists. So the original claim that "Tagging cannot be implemented efficiently on no_std" seems no longer true.

On the other hand, restricting certain features under a conservative assumption seems not ideal for downstream users. Not to mention all `Copy`able types, a typical use of `tag_with` is to count the total number of notifications for a set of events before waking the notified listeners and guaranteeing the linearization of publication order, which only costs one `Atomic::fetch_add`. This PR is to warn users of its call site (under locks, non-reentrant, etc.) as a more ergonomic alternative.

Another alternative is to wait for the stabilization of [the `ergonomic_clones` feature](https://github.com/rust-lang/rust/issues/132290), and then require the `UseCloned` trait instead of `Clone` for tags. Nevertheless, blocking features with future events remains questionable.